### PR TITLE
substr() function

### DIFF
--- a/plugins/fabrik_form/autofill/autofill.js
+++ b/plugins/fabrik_form/autofill/autofill.js
@@ -91,7 +91,7 @@ var Autofill =  new Class({
 			alert(Joomla.JText._('PLG_FORM_AUTOFILL_NORECORDS_FOUND'));
 		}
 		json.each(function (val, key) {
-			var k2 = key.substr(-4);
+			var k2 = key.substr(key.length-4, 4);
 			if (k2 === '_raw') {
 				key = key.replace('_raw', '');
 				var el = this.form.formElements.get(key);


### PR DESCRIPTION
With IE 8 the substr() function return the whole string when the number is negative http://rapd.wordpress.com/2007/07/12/javascript-substr-vs-substring/
