### PR TITLE
missing access level default settings and access labels in list plugins

### DIFF
--- a/plugins/fabrik_list/download/forms/fields.xml
+++ b/plugins/fabrik_list/download/forms/fields.xml
@@ -6,7 +6,7 @@
 				type="accesslevel" 
 				default="1"
 				repeat="true"
-				label="COM_FABRIK_ACCESS" />
+				label="PLG_FABRIK_LIST_DOWNLOAD_ACCESS_LABEL" />
 				
 			<field name="download_button_label" 
 				type="text"

--- a/plugins/fabrik_list/download/language/en-GB/en-GB.plg_fabrik_list_download.ini
+++ b/plugins/fabrik_list/download/language/en-GB/en-GB.plg_fabrik_list_download.ini
@@ -4,6 +4,7 @@
 ; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
+PLG_FABRIK_LIST_DOWNLOAD_ACCESS_LABEL="Access"
 PLG_FABRIK_LIST_DOWNLOAD_TABLE_LABEL="Foreign Table"
 PLG_FABRIK_LIST_DOWNLOAD_TABLE_DESC="If your download files (typically a File Upload element) are in a related table, enter the tablename here AND provide the Foreign Key.  Leave both fields blank if download files are on this table."
 PLG_FABRIK_LIST_DOWNLOAD_FK_LABEL="Foreign Key"

--- a/plugins/fabrik_list/email/forms/fields.xml
+++ b/plugins/fabrik_list/email/forms/fields.xml
@@ -7,7 +7,7 @@
 				type="accesslevel"
 				default="1"
 				repeat="true"
-				label="COM_FABRIK_ACCESS"/>
+				label="PLG_FABRIK_LIST_EMAIL_ACCESS_LABEL"/>
 		
 			<field name="emailtable_from_user" type="radio" default="0" 
 				repeat="true"

--- a/plugins/fabrik_list/email/language/en-GB/en-GB.plg_fabrik_list_email.ini
+++ b/plugins/fabrik_list/email/language/en-GB/en-GB.plg_fabrik_list_email.ini
@@ -4,6 +4,7 @@
 ; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
+PLG_FABRIK_LIST_EMAIL_ACCESS_LABEL="Access"
 PLG_LIST_EMAIL_SEND_FROM_USER_LABEL="Send from user"
 PLG_LIST_EMAIL_SEND_FROM_USER_DESC="Use the current user's email address to send mail. Might not work on some webhosts."
 PLG_LIST_EMAIL_TO_TYPE_LABEL="Get email address from"

--- a/plugins/fabrik_list/inlineedit/forms/fields.xml
+++ b/plugins/fabrik_list/inlineedit/forms/fields.xml
@@ -5,6 +5,7 @@
 		<fieldset name="plg-list-inlineedit">
 			<field name="inline_access"
 				type="accesslevel"
+				default="1"
 				repeat="true"
 				label="PLG_LIST_INLINE_ACCESS_LABEL" />
 			

--- a/plugins/fabrik_list/update_col/forms/fields.xml
+++ b/plugins/fabrik_list/update_col/forms/fields.xml
@@ -4,6 +4,7 @@
 		<fieldset name="plg-list-radius_search">
 			<field name="updatecol_access" 
 				type="accesslevel"
+				default="1"
 				repeat="true"
 				label="PLG_LIST_UPDATE_COL_ACCESS_LABEL" />
 				


### PR DESCRIPTION
I've set the missing default access levels to 1 (public, as in the other list plugins) but maybe 3 (special) would be better for security reasons.
