### PR TITLE
Keep &id in pagination URLs at list view with Content plugin

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -6420,6 +6420,15 @@ class FabrikFEModelList extends JModelForm {
 				if ($el === false) {
 					$qs[] = "$k=$v";
 				} else {
+					//******* e-kinst
+					# let's keep &id for com_content - in other case in Content Plugin
+					# we have incorrect action in form and as a result bad pagination URLS.
+					# In any case this will not be excessive (I suppose)
+					if($k == 'id'  &&  $option == 'com_content') {		# at least. May be even
+						$qs[] = "$k=$v";				# $option != 'com_fabrik'
+					}
+					// * /e-kinst
+					
 					//check if its a tag element if it is we want to clear that when we clear the form
 					// (if the filter was set via the url we generally want to keep it though
 


### PR DESCRIPTION
Current version looses &id in pagination URLs when using {fabrik list.........} and in <form> action attribute too. This results in errors like 404.
