### PR TITLE
Typo in date.php?, additions for accessibility

### DIFF
--- a/components/com_fabrik/views/list/view.html.php
+++ b/components/com_fabrik/views/list/view.html.php
@@ -440,21 +440,28 @@ class FabrikViewList extends JView{
 	{
 		$this->buttons = new stdClass();
 		$buttonProperties = array('class' => 'fabrikTip', 'opts' => "{notice:true}", 'title' => '<span>'.JText::_('COM_FABRIK_EXPORT_TO_CSV').'</span>');
+		$buttonProperties['alt'] = JText::_('COM_FABRIK_EXPORT_TO_CSV');			
 		$this->buttons->csvexport =  FabrikHelperHTML::image('csv-export.png', 'list', $this->tmpl, $buttonProperties);
 		$buttonProperties['title'] = '<span>'.JText::_('COM_FABRIK_IMPORT_FROM_CSV').'</span>';
+		$buttonProperties['alt'] = JText::_('COM_FABRIK_IMPORT_TO_CSV');	
 		$this->buttons->csvimport = FabrikHelperHTML::image('csv-import.png', 'list', $this->tmpl, $buttonProperties);
 		$buttonProperties['title'] = '<span>'.JText::_('COM_FABRIK_SUBSCRIBE_RSS').'</span>';
+		$buttonProperties['alt'] = JText::_('COM_FABRIK_SUBSCIBE_RSS');	
 		$this->buttons->feed = FabrikHelperHTML::image('feed.png', 'list', $this->tmpl, $buttonProperties);
 		$buttonProperties['title'] = '<span>'.JText::_('COM_FABRIK_EMPTY').'</span>';
+		$buttonProperties['alt'] = JText::_('COM_FABRIK_EMPTY');			
 		$this->buttons->empty = FabrikHelperHTML::image('trash.png', 'list', $this->tmpl, $buttonProperties);
 
 		$buttonProperties['title'] = '<span>'.JText::_('COM_FABRIK_GROUP_BY').'</span>';
+		$buttonProperties['alt'] = JText::_('COM_FABRIK_GROUP_BY');
 		$this->buttons->groupby = FabrikHelperHTML::image('group_by.png', 'list', $this->tmpl, $buttonProperties);
 
 		$buttonProperties['title'] = '<span>'.JText::_('COM_FABRIK_FILTER').'</span>';
+		$buttonProperties['alt'] = JText::_('COM_FABRIK_FILTER');		
 		$this->buttons->filter = FabrikHelperHTML::image('filter.png', 'list', $this->tmpl, $buttonProperties);
 
 		$buttonProperties['title'] = '<span>'.JText::_('COM_FABRIK_ADD').'</span>';
+		$buttonProperties['alt'] = JText::_('COM_FABRIK_ADD');	
 		$this->buttons->add = FabrikHelperHTML::image('add.png', 'list', $this->tmpl, $buttonProperties);
 	}
 


### PR DESCRIPTION
I assume it's a type in date.php, please verify (there's a deleted thread about this http://fabrikar.com/forums/showthread.php?t=25464)

Following accessibility rules i've added some missing "alt" descriptions to list buttons.
There are still missing "titles" in filter fields and page limit select, I don't know where to do this.

Filter element should be something like

`<input class="fabrik_filter" type="search" title="search all" size="20" 
value="" name="fabrik_list_filter_all_1_com_fabrik_1">`

pagination
`<select id="limit1" class="inputbox" title="page limit" name="limit1" size="1" onchange="">`
