### PR TITLE
Warning: json_decode() expects parameter 1 to be string

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -1291,14 +1291,15 @@ class FabrikFEModelList extends JModelForm {
 				// $$$ hugh - not everything is JSON, some stuff is just plain strings.
 				// So we need to see if JSON encoding failed, and only use result if it didn't.
 				// $v = json_decode($v, true);
+			if (is_array($v)) {
+				$v = JArrayHelper::getValue($v, $repeatCounter);
+			} else {
 				$v2 = json_decode($v, true);
 				if ($v2 !== null) {
-					$v = $v2;
+				$v = $v2;
 				}
-				if (is_array($v)) {
-					$v = JArrayHelper::getValue($v, $repeatCounter);
-				}
-			}
+			}		
+		}
 			$array['rowid'] = $this->getSlug($row);
 			$array['listid'] = $table->id;
 			$link = JRoute::_($this->parseMessageForRowHolder($customLink, $array));


### PR DESCRIPTION
Was receiving the following message.

Warning: json_decode() expects parameter 1 to be string, array given in Z:\Web\wamp\www\dev\xxxx\components\com_fabrik\models\list.php on line 1294

This commit seems to fix it and produce the same results without the error.

http://tinypic.com/r/2m26hia/5

Both screenshots were produced by using the following around 1306

```
    echo '<pre>'; print_r($link); echo '</pre>'; 
    return $link;
```
