### PR TITLE
Little fix for birthday and time - one particular displaying case

### DIFF
--- a/plugins/fabrik_element/birthday/birthday.php
+++ b/plugins/fabrik_element/birthday/birthday.php
@@ -383,7 +383,8 @@ class plgFabrik_ElementBirthday extends plgFabrik_Element
 		$jubileum = array('0','25','75');
 		$groupModel = $this->getGroup();
 		//Jaanus: json_decode replaced with FabrikWorker::JSONtoData that made visible also single data in repeated group
-		$data = $groupModel->canRepeat() ? FabrikWorker::JSONtoData($data, true) : array($data);
+		//Jaanus: removed condition canrepeat() from renderListData: weird result such as 05",null,"1940.07.["1940 (2011) when not repeating but still join and merged. Using isJoin() instead
+		$data = $groupModel->isJoin() ? FabrikWorker::JSONtoData($data, true) : array($data);
 		$data = (array) $data;
 		$ft = $params->get('list_date_format', 'd.m.Y');
 		//$ft = $params->get('birthday_format', 'd.m.Y'); //$ft = $params->get('birthday_format', '%Y-%m-%d');

--- a/plugins/fabrik_element/time/time.php
+++ b/plugins/fabrik_element/time/time.php
@@ -261,7 +261,8 @@ class plgFabrik_ElementTime extends plgFabrik_Element
 		$db = FabrikWorker::getDbo();
 		$params = $this->getParams();
 		$groupModel = $this->getGroup();
-		$data = $groupModel->canRepeat() ? FabrikWorker::JsonToData($data) : array($data);
+		//Jaanus: removed condition canrepeat() from renderListData: weird result such as ["00:03:45","00 when not repeating but still join and merged. Using isJoin() instead
+		$data = $groupModel->isJoin() ? FabrikWorker::JSONtoData($data, true) : array($data);
 		$data = (array) $data;
 		$ft = $params->get('list_time_format', 'H:i:s');
 		$sep = $params->get('time_separatorlabel', JText::_(':'));


### PR DESCRIPTION
To be displayed correctly in list view when no repeat, but still more than 1 joined rows and display mode is merge. Hoping this is correct way to fix the issue. 
