### PR TITLE
Fatal error: Call to a member function getFullName() on a non-object

### DIFF
--- a/plugins/fabrik_element/fileupload/fileupload.php
+++ b/plugins/fabrik_element/fileupload/fileupload.php
@@ -517,9 +517,9 @@ class plgFabrik_ElementFileupload extends plgFabrik_Element
 				return '';
 			}
 			$aclEl = $this->getFormModel()->getElement($params->get('fu_download_acl', ''), true);
-			$aclEl = $aclEl->getFullName();
 			if (!empty($aclEl))
 			{
+				$aclEl = $aclEl->getFullName();
 				$aclElraw = $aclEl . '_raw';
 				$user = JFactory::getUser();
 				$groups = $user->getAuthorisedViewLevels();
@@ -2301,9 +2301,9 @@ class plgFabrik_ElementFileupload extends plgFabrik_Element
 			exit;
 		}
 		$aclEl = $this->getFormModel()->getElement($params->get('fu_download_acl', ''), true);
-		$aclEl = $aclEl->getFullName();
 		if (!empty($aclEl))
 		{
+			$aclEl = $aclEl->getFullName();
 			$aclElraw = $aclEl . '_raw';
 			$user = JFactory::getUser();
 			$groups = $user->getAuthorisedViewLevels();


### PR DESCRIPTION
Fatal error: Call to a member function getFullName() on a non-object in \plugins\fabrik_element\fileupload\fileupload.php on line 520

Looking for a non object, so I assume it needs to be moved down one line to be processed with 

if (!empty($aclEl))    ??
