### PR TITLE
[Formatting] Spelling errors in code

### DIFF
--- a/components/com_fabrik/models/connection.php
+++ b/components/com_fabrik/models/connection.php
@@ -163,10 +163,10 @@ class FabrikFEModelConnection extends JModel {
 
 			$debug 		= $conf->getValue('config.debug');
 
-			$deafult_options= array('driver' => $driver, 'host' => $host, 'user' => $user, 'password' => $password, 'database' => $database, 'prefix' => $prefix);
+			$default_options= array('driver' => $driver, 'host' => $host, 'user' => $user, 'password' => $password, 'database' => $database, 'prefix' => $prefix);
 			$options = $this->getConnectionOptions($cn);
 
-			if ($this->_compareConnectionOpts($deafult_options, $options)) {
+			if ($this->_compareConnectionOpts($default_options, $options)) {
 				$dbs[$cn->id] = FabrikWorker::getDbo();
 			} else {
 				$dbs[$cn->id] = JDatabase::getInstance($options);
@@ -188,7 +188,7 @@ class FabrikFEModelConnection extends JModel {
 					$app = JFactory::getApplication();
 
 					if (!$app->isAdmin()) {
-						JError::raiseError(E_ERROR, 'Could not connection to database', $deafult_options);
+						JError::raiseError(E_ERROR, 'Could not connection to database', $default_options);
 						jexit('Could not connection to database - possibly a menu item which doesn\'t link to a fabrik table');
 					} else {
 						// $$$ rob - unset the connection as caching it will mean that changes we make to the incorrect connection in admin, will not result


### PR DESCRIPTION
Call me paranoid, (ocd..yup that too).. but having spelling errors in constants, vars, etc may cause gremlins and wasted time down the road (been there done that heh heh). I'm not trying to be a boo-boo cop I promise. If it would be easier to wait for a release milestone I'll hold off with this kind of stuff or if you don't care let me know plz so I don't waste our time.
