### PR TITLE
Improvements for dbjoin & cdd vol 2

### DIFF
--- a/plugins/fabrik_element/cascadingdropdown/forms/fields.xml
+++ b/plugins/fabrik_element/cascadingdropdown/forms/fields.xml
@@ -27,7 +27,7 @@
 				
 			<field connection="params_cascadingdropdown_connection" connection_in_repeat="false" description="PLG_ELEMENT_CDD_LABEL_DESC" excludejoined="1" label="PLG_ELEMENT_CDD_LABEL_LABEL" name="cascadingdropdown_label" table="params_cascadingdropdown_table" type="element"/>
 				
-			<field description="PLG_ELEMENT_CDD_LABEL_CONCAT_DESC" label="PLG_ELEMENT_CDD_LABEL_CONCAT_LABEL" name="cascadingdropdown_label_concat" type="text"/>
+			<field description="PLG_ELEMENT_CDD_LABEL_CONCAT_DESC" label="PLG_ELEMENT_CDD_LABEL_CONCAT_LABEL" name="cascadingdropdown_label_concat" cols="40" rows="8" type="textarea"/>
 		</fieldset>
 		
 		<fieldset addfieldpath="/administrator/components/com_fabrik/models/fields" name="plg-cascadingdropdown-watch">
@@ -37,7 +37,7 @@
 		</fieldset>
 		
 		<fieldset addfieldpath="/administrator/components/com_fabrik/models/fields" name="plg-cascadingdropdown-advanced">
-			<field description="PLG_ELEMENT_CDD_WHERE_DESC" label="PLG_ELEMENT_CDD_WHERE_LABEL" name="cascadingdropdown_filter" type="text"/>
+			<field description="PLG_ELEMENT_CDD_WHERE_DESC" label="PLG_ELEMENT_CDD_WHERE_LABEL" name="cascadingdropdown_filter" cols="40" rows="8" type="textarea"/>
 				
 		
 			

--- a/plugins/fabrik_element/databasejoin/databasejoin.php
+++ b/plugins/fabrik_element/databasejoin/databasejoin.php
@@ -538,7 +538,8 @@ class plgFabrik_ElementDatabasejoin extends plgFabrik_ElementList
 		$desc = $params->get('join_desc_column', '');
 		if ($desc !== '')
 		{
-			$sql .= ', ' . $db->quoteName($desc) . ' AS description';
+			$desc = "REPLACE(".$db->quoteName($desc).", '\n', '<br />')";
+			$sql .= ', ' . $desc . ' AS description';
 		}
 		$sql .= $this->getAdditionalQueryFields();
 		$sql .= ' FROM ' . $db->quoteName($table) . ' AS ' . $db->quoteName($join->table_join_alias);

--- a/plugins/fabrik_element/databasejoin/forms/fields.xml
+++ b/plugins/fabrik_element/databasejoin/forms/fields.xml
@@ -39,9 +39,9 @@
 			
 		<field connection="params_join_conn_id" description="PLG_ELEMENT_DBJOIN_JOIN_LABEL_DESC" label="PLG_ELEMENT_DBJOIN_JOIN_LABEL_LABEL" name="join_val_column" table="params_join_db_name" type="listfields"/>
 			
-		<field description="PLG_ELEMENT_DBJOIN_OR_CONCAT_LABEL_DESC" label="PLG_ELEMENT_DBJOIN_OR_CONCAT_LABEL_LABEL" name="join_val_column_concat" size="70" type="text"/>
+		<field description="PLG_ELEMENT_DBJOIN_OR_CONCAT_LABEL_DESC" label="PLG_ELEMENT_DBJOIN_OR_CONCAT_LABEL_LABEL" name="join_val_column_concat" cols="40" rows="8" type="textarea"/>
 			
-		<field description="PLG_ELEMENT_DBJOIN_WHERE_STATEMENT_DESC" label="PLG_ELEMENT_DBJOIN_WHERE_STATEMENT_LABEL" name="database_join_where_sql" size="70" type="text"/>
+		<field description="PLG_ELEMENT_DBJOIN_WHERE_STATEMENT_DESC" label="PLG_ELEMENT_DBJOIN_WHERE_STATEMENT_LABEL" name="database_join_where_sql" cols="40" rows="8" type="textarea"/>
 			
 		<field default="1" description="PLG_ELEMENT_DBJOIN_JOIN_WHERE_ACCESS_DESC" label="PLG_ELEMENT_DBJOIN_JOIN_WHERE_ACCESS_LABEL" name="database_join_where_access" type="accesslevel"/>
 			


### PR DESCRIPTION
Admin form fields for concat labels and where statements are textareas to make easier handling possible long subqueries
DB join: description field shows now linebreaks that were stripped out if description field was textarea and linebreaks were \n -s.
