### PR TITLE
Errors in geocode cron plugin

### DIFF
--- a/plugins/fabrik_cron/geocode/geocode.php
+++ b/plugins/fabrik_cron/geocode/geocode.php
@@ -66,7 +66,7 @@ class plgFabrik_CronGeocode extends plgFabrik_Cron {
 		$geocode_state_element = $geocode_state_element_long ? FabrikString::shortColName($geocode_state_element_long) : '';
 		$geocode_zip_element_long = $params->get('geocode_zip_element');
 		$geocode_zip_element = $geocode_zip_element_long ? FabrikString::shortColName($geocode_zip_element_long) : '';
-		$geocode_country_element_long = $params->get('geocode_country_userid_element');
+		$geocode_country_element_long = $params->get('geocode_country_element');
 		$geocode_country_element = $geocode_country_element_long ? FabrikString::shortColName($geocode_country_element_long) : '';
 		$geocode_when = $params->get('geocode_zip_element', '1');
 
@@ -136,7 +136,7 @@ class plgFabrik_CronGeocode extends plgFabrik_Cron {
 						}
 						if ($geocode_country_element) {
 							if ($row->$geocode_country_element) {
-								$a_full_addr[] = $row->$geocode_zip_element;
+								$a_full_addr[] = $row->$geocode_country_element;
 							}
 						}
 						// now explode the address into a string


### PR DESCRIPTION
There were wrong element name that kept the plugin to retreive correctly the country.
