### PR TITLE
wysiwyg textarea size

### DIFF
--- a/plugins/fabrik_element/textarea/textarea.php
+++ b/plugins/fabrik_element/textarea/textarea.php
@@ -251,7 +251,7 @@ class plgFabrik_ElementTextarea extends plgFabrik_Element
 			else
 			{
 				$editor = JFactory::getEditor();
-				$str = $editor->display($name, $value, $rows, $rows, $cols, $rows, true, $id);
+				$str = $editor->display($name, $value, $cols*10, $rows*15, $cols, $rows, true, $id);
 			}
 		}
 		else


### PR DESCRIPTION
small modification to respect element settings for wysiwyg editor (tested with TinyMCE and JCE):

now the textarea has (nearly) the same size for settings
wysiwyg = no
and 
wysiwyg=Yes  in editor and in text mode
