### PR TITLE
Allow using non-default collations

### DIFF
--- a/administrator/components/com_fabrik/models/fields/collation.php
+++ b/administrator/components/com_fabrik/models/fields/collation.php
@@ -54,8 +54,9 @@ class JFormFieldCollation extends JFormFieldList
 	protected function getOptions()
 	{
 		$db = JFactory::getDbo();
-		$db->setQuery('SHOW COLLATION WHERE ' . $db->quoteName('Default') . ' = ' . $db->quote('Yes'));
+		$db->setQuery('SHOW COLLATION WHERE ' . $db->quoteName('Compiled') . ' = ' . $db->quote('Yes'));
 		$rows = $db->loadObjectList();
+		sort($rows);
 		require_once COM_FABRIK_FRONTEND . '/helpers/image.php';
 		$opts = array();
 		foreach ($rows as $row)


### PR DESCRIPTION
WHERE Default = 'Yes' prevented using of non-default collations forcing to change e.g utf8_estonian_ci against some other. When this other wasn't choosen then big5_chinese_ci as the first in options list was set as table collation. See http://fabrikar.com/forums/showthread.php?t=29950
Furthermore, the collation names were not ordered by their names.
