### PR TITLE
Allow using all compiled collations, not only 'Default'

### DIFF
--- a/administrator/components/com_fabrik/models/fields/collation.php
+++ b/administrator/components/com_fabrik/models/fields/collation.php
@@ -54,8 +54,9 @@ class JFormFieldCollation extends JFormFieldList
 	protected function getOptions()
 	{
 		$db = JFactory::getDbo();
-		$db->setQuery('SHOW COLLATION WHERE ' . $db->quoteName('Default') . ' = ' . $db->quote('Yes'));
+		$db->setQuery('SHOW COLLATION WHERE ' . $db->quoteName('Compiled') . ' = ' . $db->quote('Yes'));
 		$rows = $db->loadObjectList();
+		sort($rows);
 		require_once COM_FABRIK_FRONTEND . '/helpers/image.php';
 		$opts = array();
 		foreach ($rows as $row)


### PR DESCRIPTION
Sometimes we just use other collations than marked as Default = 'Yes'. The same is proposed for main code.
