### PR TITLE
Replacing DATETIME against TIME in timer el, rejecting any date part of data

### DIFF
--- a/plugins/fabrik_element/timer/timer.php
+++ b/plugins/fabrik_element/timer/timer.php
@@ -30,44 +30,7 @@ class plgFabrik_ElementTimer extends plgFabrik_Element
 	/** @var  string  db table field type */
 	protected $fieldDesc = 'TIME';
 
-	/**
-	 * Manupulates posted form data for insertion into database
-	 *
-	 * @param   mixed  $val   this elements posted form data
-	 * @param   array  $data  posted form data
-	 *
-	 * @return  mixed
-	 */
 	 // Jaanus: works better when using datatype 'TIME' as above and forgetting any date part of data :)
-
-	public function storeDatabaseFormat($val, $data)
-	{
-		$return = $val;
-		$format = '%H:%i:%s';
-		$timebits = FabrikWorker::strToDateTime($return, $format);
-		$return = date('H:i:s', $timebits['timestamp']);
-		return $return;
-	}
-
-	/**
-	 * Shows the data formatted for the list view
-	 *
-	 * @param   string  $data      elements data
-	 * @param   object  &$thisRow  all the data in the lists current row
-	 *
-	 * @return  string	formatted value
-	 */
-
-	public function renderListData($data, &$thisRow)
-	{
-		if ($data != '')
-		{
-			$format = '%H:%i:%s';
-			$timebits = FabrikWorker::strToDateTime($data, $format);
-			$data = date('H:i:s', $timebits['timestamp']);
-		}
-		return $data;
-	}
 
 	/**
 	 * Determines if the element can contain data used in sending receipts,


### PR DESCRIPTION
There is no good reason to work with date format 'Y-m-d H:i:s' or '%Y-%m-%d %H:%i:%s'
as the value shown in form&details/list is a time 'H:i:s' anyway without any date part.  
Appearance of the value as datetime in database (e.g. '1999-01-01 00:02:34') is nothing else but confusing. See http://fabrikar.com/forums/showthread.php?t=30490

The plugin works fine on the TIME field. But 
NOTICE - this commit doesn't resolve another (not very serious) issue: 
In some unknown reason - when creating a new element the new databasefield is (and was) TEXT instead of TIME (earlier - instead of DATETIME). Fortunately the element seems to be working also well on this datatype, but this is rather confusing as well.
