### PR TITLE
missing getElement('.lngdms') in googlemap.js

### DIFF
--- a/plugins/fabrik_element/googlemap/googlemap.js
+++ b/plugins/fabrik_element/googlemap/googlemap.js
@@ -378,6 +378,7 @@ var FbGoogleMap = new Class({
 		var dms = this.element.getElement('.latdms');
 		var latdms = dms.get('value').replace('S', '-');
 		latdms = latdms.replace('N', '');
+		dms = this.element.getElement('.lngdms');
 		var lngdms = dms.get('value').replace('W', '-');
 		lngdms = lngdms.replace('E', '');
 


### PR DESCRIPTION
I think I've got the googlemap element DMS issue.

Please check and handle googlemap-min.js
