### PR TITLE
Resolving a weird issue related to inline edit

### DIFF
--- a/plugins/fabrik_element/databasejoin/databasejoin.php
+++ b/plugins/fabrik_element/databasejoin/databasejoin.php
@@ -2799,6 +2799,10 @@ class plgFabrik_ElementDatabasejoin extends plgFabrik_ElementList
 	public function dataIsNull($data, $val)
 	{
 		$default = $this->getDefaultValue();
+		if (!is_array($default)) 
+		{
+			$default = array($default);
+		}
 		$keys = array_keys($default);
 		if (is_array($default) && count($default) == 1 && $default[$keys[0]] == $val && $val == '')
 		{


### PR DESCRIPTION
When using list plugin inline edit in backend and the list have some dbjoin elements, then after saving I see in this row:

Warning: array_keys() expects parameter 1 to be array, string given in /home/..../plugins/fabrik_element/databasejoin/databasejoin.php on line 2802
