### PR TITLE
Update plugins/fabrik_element/databasejoin/databasejoin.php

### DIFF
--- a/plugins/fabrik_element/databasejoin/databasejoin.php
+++ b/plugins/fabrik_element/databasejoin/databasejoin.php
@@ -94,7 +94,7 @@ class PlgFabrik_ElementDatabasejoin extends PlgFabrik_ElementList
 
 		// Make sure same connection as this table
 		$fullElName = JArrayHelper::getValue($opts, 'alias', $table . '___' . $element->name);
-		if ($params->get('join_conn_id') == $connection->get('_id') || $element->plugin != 'databasejoin')
+		if ($params->get('join_conn_id') == $connection->get('id') || $element->plugin != 'databasejoin')
 		{
 			$join = $this->getJoin();
 			if (!$join)


### PR DESCRIPTION
I have fixed a bug that in database-join caused by a a change in the parent's variable name that was not reflected in this class. Check the link below for more details.

http://fabrikar.com/forums/showthread.php?t=31983
