### PR TITLE
Removing unprocessed content plugin code from view (hoping that this time the pull request is correct)

### DIFF
--- a/components/com_fabrik/models/form.php
+++ b/components/com_fabrik/models/form.php
@@ -4012,6 +4012,13 @@ class FabrikFEModelForm extends FabModelForm
 		}
 		$w = new FabrikWorker;
 		$text = $w->parseMessageForPlaceHolder($text, $this->_data, true);
+		// Jaanus: to remove content plugin code from intro and/or outro when plugins are not processed
+		$params = $this->getParams();
+		$jplugins = (int) $params->get('process-jplugins', '2');
+		if ($jplugins == 0 || ($jplugins == 2 && $this->isEditable()))
+		{
+			$text = preg_replace("/{\s*.*?}/i", '', $text);
+		}
 		return $text;
 	}
 


### PR DESCRIPTION
When we don't need content plugin to be processed in form view (in intro, outro etc) 
and this option is choosen in form admin, then we shouldn't see anything but we see the code (e.g {fabrik view=list id=1 table___element=[rowid]} ) that has no sense. With this code - after regular {placeholders} are parsed, everything that is between {} and not parsed is just removed from view. 

Rob, you intended to make these changes manually but I didn't find them. It is not hard at all to create a new pull request. I hope this time it's without "surprises". 
