### PR TITLE
Added time as a default element plugin for time fields

### DIFF
--- a/administrator/components/com_fabrik/models/list.php
+++ b/administrator/components/com_fabrik/models/list.php
@@ -1232,9 +1232,11 @@ class FabrikModelList extends FabModelAdmin
 							break;
 						case "datetime":
 						case "date":
-						case "time":
 						case "timestamp":
 							$plugin = 'date';
+							break;
+						case "time":
+							$plugin = 'time';
 							break;
 						default:
 							$plugin = 'field';


### PR DESCRIPTION
As the 'time' element plugin is now included in main package - 
it seems that there is no longer any special reason why should we create automatically a 'date' element type on TIME fields when creating lists and form from existing db tables.

Possible TODO ideas:

1) use more plugin names in this function - e.g 
case "date"
if 'birthtday' exist and is enabled (how to check it?)
$plugin = 'birthday';
break;
Else the plugin would be 'date'

2) to allow users set own defaults, 
e.g that if a field is int and (fk) index then default element type would be 'databasejoin'
