### PR TITLE
Fabrik 3.1: JUtility::sendMail() throws fatal error

### DIFF
--- a/plugins/fabrik_cron/email/email.php
+++ b/plugins/fabrik_cron/email/email.php
@@ -97,7 +97,8 @@ class plgFabrik_Cronemail extends plgFabrik_Cron
 							$thismsg = eval($thismsg);
 						}
 						$thissubject = $w->parseMessageForPlaceHolder($subject, $row);
-						$res = JUTility::sendMail($MailFrom, $FromName, $thisto, $thissubject, $thismsg, true);
+						$mail = JFactory::getMailer(); 				
+						$res = $mail->sendMail($MailFrom, $FromName, $thisto, $thissubject, $thismsg, true);
 						if (!$res)
 						{
 							$this->log .= "\n failed sending to $thisto";


### PR DESCRIPTION
Fatal error: Call to undefined method JUtility::sendMail() in C:\xampp\htdocs\j3\plugins\fabrik_cron\email\email.php on line 100

JUtility::sendMail() not longer supported in J!3;
Code taken from frabrik_form/email.php

Not sure if it takes the parameters exactly as in JUtility::sendMail()
