### PR TITLE
Wrong Bootstrap class left in dropdown list in the xml file

### DIFF
--- a/plugins/fabrik_element/user/forms/fields.xml
+++ b/plugins/fabrik_element/user/forms/fields.xml
@@ -37,7 +37,6 @@
 			<field name="update_on_edit"
 				type="list"
 				default="0"
-				class="btn-group"
 				description="PLG_ELEMENT_USER_UPDATE_ON_EDIT_DESC"
 				label="PLG_ELEMENT_USER_UPDATE_ON_EDIT_LABEL">
 					<option value="0">JNO</option>


### PR DESCRIPTION
There was a class="btn-group" that kept the dropdown for "update on edit" to work.
