### PR TITLE
back-button in details template; CSS + dropdown for layout select still pointing to "form"

### DIFF
--- a/components/com_fabrik/views/details/tmpl/bootstrap/default_actions.php
+++ b/components/com_fabrik/views/details/tmpl/bootstrap/default_actions.php
@@ -15,7 +15,9 @@ if ($this->hasActions) : ?>
 	<div class="row-fluid">
 		<div class="span12">
 			<div class="btn-group">
-				<?php echo $form->nextButton . ' ' . $form->prevButton; ?>
+				<?php echo $form->nextButton . ' ' . $form->prevButton;
+				echo $form->gobackButton  . ' ' . $this->message;
+				?>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
back-button missing in details template

BTW: 
template/custom_css.php are still included from "form" (FF showing ..../com_fabrik/views/form/tmpl/bootstrap/template_css.php?c=2&view=details)
is this intentionally?

backend template "Details view" select dropdown still showing the "form" folders
