### PR TITLE
Addition to the previous fix related to 12dbf29 

### DIFF
--- a/administrator/components/com_fabrik/models/list.php
+++ b/administrator/components/com_fabrik/models/list.php
@@ -1221,6 +1221,7 @@ class FabrikModelList extends FabModelAdmin
 						case "mediumint":
 						case "bigint":
 						case "varchar":
+						case "time":
 							$plugin = 'field';
 							break;
 						case "text":
@@ -1231,7 +1232,6 @@ class FabrikModelList extends FabModelAdmin
 							break;
 						case "datetime":
 						case "date":
-						case "time":
 						case "timestamp":
 							$plugin = 'date';
 							break;


### PR DESCRIPTION
Little userfriendly addition to this;
https://github.com/Fabrik/fabrik/commit/e36a604b94869e95a94708970106f774844c60bb
If we have TIME field in db and no time element installed, then the only element plugin that is able to work normally with this field is 'field' plugin (not 'date' plugin at all).
