### PR TITLE
Fix import from CSV

### DIFF
--- a/components/com_fabrik/models/form.php
+++ b/components/com_fabrik/models/form.php
@@ -1655,6 +1655,8 @@ class FabrikFEModelForm extends FabModelForm
 				{
 					$listModel->encrypt[] = $elementModel->getElement()->name;
 				}
+				// Following line added to fix importcsv where data from first row is used for every row.
+				$elementModel->defaults = null;
 				$elementModel->onStoreRow($data);
 			}
 		}

--- a/components/com_fabrik/models/importcsv.php
+++ b/components/com_fabrik/models/importcsv.php
@@ -736,7 +736,7 @@ class FabrikFEModelImportcsv extends JModelForm
 			}
 			if (!$tableJoinsFound)
 			{
-				$formModel->formData = $aRow;
+				$formModel->formData = $formModel->formDataWithTableName = $aRow;
 				if (!in_array(false, FabrikWorker::getPluginManager()->runPlugins('onImportCSVRow', $model, 'list')))
 				{
 					$formModel->processToDB();


### PR DESCRIPTION
Importing from CSV was importing blank rows because
formDataWithTableNames was not being set in importcsv.php.

Importing from CSV was repeating data from first row in all rows because
data from first row was being saved in defaults (in elements.php getValue - though fix is in form.php).
