### PR TITLE
Fix List groupby display on linked fields or text

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -1116,6 +1116,8 @@ class FabrikFEModelList extends JModelForm
 		{
 			$w = new FabrikWorker;
 
+		/**
+		  * FIX - Group-by for display should be same as group-by used to get data and should be _raw !!
 			// 3.0 if not group by template spec'd by group but assigned in qs then use that as the group by tmpl
 			$requestGroupBy = $input->get('group_by', '');
 			if ($requestGroupBy == '')
@@ -1131,6 +1133,9 @@ class FabrikFEModelList extends JModelForm
 			{
 				$groupTemplate = '{' . $requestGroupBy . '}';
 			}
+		**/
+			$groupTemplate = '{' . $groupBy . '_raw}';
+
 			$groupedData = array();
 			$thisGroupedData = array();
 			$groupBy = FabrikString::safeColNameToArrayKey($groupBy);


### PR DESCRIPTION
When you group a list on a calculated field (which is stored in the database as a text type) or on a linked field, the groupby row displayed is missing the group-by value or the anchor is screwed up by the link.

These are caused by use of non-raw placeholders. Also, code seems to be much more complicated than it needs to be - it gets the group-by clause used to get the data and it can use this for processing.

This fix simplifies the code (until it has been reviewed, old code has been commented out rather than removed) and makes it work as advertised.
