### PR TITLE
Display List access options for CSV Import/Export

### DIFF
--- a/administrator/components/com_fabrik/models/forms/list.xml
+++ b/administrator/components/com_fabrik/models/forms/list.xml
@@ -277,6 +277,18 @@
 				description="COM_FABRIK_FIELD_DROP_RECORDS_DESC"
 				label="COM_FABRIK_FIELD_DROP_RECORDS_LABEL" />
 				
+			<field name="csv_export_frontend"
+				type="accesslevel"
+				default="2"
+				description="COM_FABRIK_FIELD_CSV_EXPORT_DESC"
+				label="COM_FABRIK_FIELD_CSV_EXPORT_LABEL" />
+				
+			<field name="csv_import_frontend"
+				type="accesslevel"
+				default="3"
+				description="COM_FABRIK_FIELD_CSV_IMPORT_DESC"
+				label="COM_FABRIK_FIELD_CSV_IMPORT_LABEL" />
+				
 		</fieldset>
 	
 		<fieldset name="filters">


### PR DESCRIPTION
Fabrik already has support for whether CSV options are shown for Lists,
however the List Access page does not allow view groups to be set for
these.

This fix enables these settings to be displayed and set.
