### PR TITLE
Fix repeating data id length 11 not 6

### DIFF
--- a/administrator/components/com_fabrik/models/group.php
+++ b/administrator/components/com_fabrik/models/group.php
@@ -289,8 +289,8 @@ class FabrikAdminModelGroup extends FabModelAdmin
 		$elements = (array) $groupModel->getMyElements();
 		$names = array();
 		$fields = $listModel->getDBFields(null, 'Field');
-		$names['id'] = "id INT( 6 ) NOT NULL AUTO_INCREMENT PRIMARY KEY";
-		$names['parent_id'] = "parent_id INT(6)";
+		$names['id'] = "id INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY";
+		$names['parent_id'] = "parent_id INT(11)";
 		foreach ($elements as $element)
 		{
 			$fname = $element->getElement()->name;


### PR DESCRIPTION
In list.php id fields are created int(11) as per Joomla standard.

Here for repeated fields they are int(6) which leads to field changes
when you later edit a repeated field.
