### PR TITLE
Don't process unpublished element

### DIFF
--- a/components/com_fabrik/models/element.php
+++ b/components/com_fabrik/models/element.php
@@ -5058,7 +5058,14 @@ FROM (SELECT DISTINCT $item->db_primary_key, $name AS value, $label FROM " . Fab
 		{
 			return false;
 		}
-		$shortName = $this->getElement()->name;
+		$element = $this->getElement();
+		// We should not process this element if it is unpublished
+		// Unpublished elements may not be in a valid state and may cause an error (white-screen)
+		if (!$element->published)
+		{
+			return false;
+		}
+		$shortName = $element->name;
 		$listModel = $this->getListModel();
 		if ($this->encryptMe())
 		{


### PR DESCRIPTION
Whitescreen can be caused when you have an UNPUBLISHED element which is
invalid (e.g. calc with invalid calculation).

This fix checks that the element is published and if not returns without
trying to provide data.

(Fix to prevent whitescreen on published element is another matter).
