### PR TITLE
Bootstrap tab template does not need next/prev

### DIFF
--- a/components/com_fabrik/views/form/tmpl/bootstrap_tabs/default_actions.php
+++ b/components/com_fabrik/views/form/tmpl/bootstrap_tabs/default_actions.php
@@ -12,11 +12,6 @@ if ($this->hasActions) : ?>
 			?>
 			</div>
 		</div>
-		<div class="span4">
-			<div class="btn-group">
-				<?php echo $form->prevButton . ' ' . $form->nextButton; ?>
-			</div>
-		</div>
 
 		<div class="span4">
 			<div class="btn-group">


### PR DESCRIPTION
Bootstrap tab template does not need next/prev as groups are navigated
using tabs rather than prev/next.
