### PR TITLE
Fix multi-page display on bootstrap_tabs

### DIFF
--- a/components/com_fabrik/models/form.php
+++ b/components/com_fabrik/models/form.php
@@ -4054,6 +4054,7 @@ class FabrikFEModelForm extends FabModelForm
 			$groupParams = $groupModel->getParams();
 			$group->intro = $groupParams->get('intro');
 			$group->columns = $groupParams->get('group_columns', 1);
+			$group->splitPage = $groupParams->get('split_page', 0);
 			if ($groupModel->canRepeat())
 			{
 				$group->tmpl = $groupParams->get('repeat_template', 'repeatgroup');

--- a/components/com_fabrik/views/form/tmpl/bootstrap_tabs/default.php
+++ b/components/com_fabrik/views/form/tmpl/bootstrap_tabs/default.php
@@ -44,11 +44,15 @@ echo $this->loadTemplate('relateddata');
 <?php
 $i = 0;
 foreach ($this->groups as $group) :
+// If this ismultipage then groups are consolidated until a group with a page break
+// So we should only show a tab if: it is first tab, or if it is a page break 
+if (!$model->isMultiPage() or ($i == 0 or $group->splitPage)) :
 ?>
 
     <li <?php if ($i == 0) echo 'class="active"'?>><a href="#group-tab<?php echo $group->id;?>" data-toggle="tab"><?php echo $group->title?></a></li>
 
 <?php
+endif;
 $i ++;
 endforeach;
 ?>


### PR DESCRIPTION
If this is a multi-page form i.e. one of the Groups has split_page set,
then groups are displayed consolidated onto tabs until the split_page
group is reached.

bootstrap_tabs currently displays tabs for all groups, but tabs for
non-split_page groups  after first are empty.

This fix puts the value of split_page into a field and only shows the
tab if needed.
