### PR TITLE
Add class name to every element.

### DIFF
--- a/components/com_fabrik/models/element.php
+++ b/components/com_fabrik/models/element.php
@@ -1942,6 +1942,7 @@ class PlgFabrik_Element extends FabrikPlugin
 	{
 		$item = $this->getElement();
 		$c = array('fabrikElementContainer', 'plg-' . $item->plugin);
+		$c[] = $element->className;
 		if ($element->hidden)
 		{
 			$c[] = 'fabrikHide';


### PR DESCRIPTION
This fix is provided by Bauer and adds the placeholder as a class for every element to enable fields to be easily identified by js.

Added as a class rather than an id to handle repeating fields.
