### PR TITLE
Fix RadioButton Label alignment

### DIFF
--- a/plugins/fabrik_element/radiobutton/radiobutton.php
+++ b/plugins/fabrik_element/radiobutton/radiobutton.php
@@ -24,7 +24,7 @@ class PlgFabrik_ElementRadiobutton extends PlgFabrik_ElementList
 	 * Does the element have a label
 	 * @var bool
 	 */
-	protected $hasLabel = false;
+	protected $hasLabel = true;
 
 	/**
 	* Method to set the element id


### PR DESCRIPTION
Set Radiobutton to use label rather than span in order that fields on
same row in form are aligned correctly.
