### PR TITLE
iclean(): Bypass call to iconv() if necessary

### DIFF
--- a/components/com_fabrik/helpers/string.php
+++ b/components/com_fabrik/helpers/string.php
@@ -282,7 +282,11 @@ class FabrikString extends JString
 			 */
 
 			// Replace accented characters with ascii equivalent e.g. é => e
-			$str = (str_replace("'", '', @iconv($fromEnc, $toEnc, $str)));
+			$str1 = (@iconv($fromEnc, $toEnc, $str));
+			if($str1) {
+				$str = $str1;
+			}
+			$str = (str_replace("'", '', $str));
 		}
 		// Compress internal whitespace and replace with _
 		$str = preg_replace('/\s+/', '_', $str);


### PR DESCRIPTION
iconv() returns an empty string on some MAMP platforms.  Bypass iconv() as required.
