### PR TITLE
Update list.php

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -8064,7 +8064,8 @@ $groupBy .= '_raw';
 		$row = JArrayHelper::fromObject($row);
 		$link = $this->parseMessageForRowHolder($link, $row);
 		
-		if(strstr($link, 'rowid='))
+		
+		if(preg_match('/([\?&]rowid=)/', htmlspecialchars_decode($link))){
 		{
 			$this->rowIdentifierAdded = true;
 		}


### PR DESCRIPTION
Fabrik adds '&rowid=...' to custom links if the link string doesn't contain the "{rowid}" placeholder. However, it is also the case that Fabrik shouldn't add '&rowid=...' to custom links if the link sets the value of rowid to something besides '{rowid}' in the query string. So, for example, a custom edit link like "?option=com_fabrik&view=form&formid=2&rowid=123" gets turned into "?option=com_fabrik&view=form&formid=2&rowid=123&rowid=whatever", which isn't what we want.

This change adds a check to see if 'rowid=' is already present in the custom link string, and if so it doesn't append the rowid argument to the end of the string.
