### PR TITLE
Present consistent listfield display order

### DIFF
--- a/administrator/components/com_fabrik/models/fields/listfields.php
+++ b/administrator/components/com_fabrik/models/fields/listfields.php
@@ -208,7 +208,8 @@ class JFormFieldListfields extends JFormFieldList
 				}
 				$aEls = $res;
 			}
-			$aEls[] = JHTML::_('select.option', '', '-');
+			// Paul - Prepend rather than append "none" option.
+			array_unshift($aEls, JHTML::_('select.option', '', '-'));
 
 			// For pk fields - we are no longer storing the key with '`' as thats mySQL specific
 			$this->value = str_replace('`', '', $this->value);

--- a/components/com_fabrik/models/form.php
+++ b/components/com_fabrik/models/form.php
@@ -2299,8 +2299,9 @@ class FabrikFEModelForm extends FabModelForm
 	{
 		$aEls = array();
 		$aEls = $this->getElementOptions($useStep, $key, false, $incRaw);
-		$aEls[] = JHTML::_('select.option', '', '-');
 		asort($aEls);
+		// Paul - Prepend rather than append "none" option.
+		array_unshift($aEls,JHTML::_('select.option', '', '-'));
 		return JHTML::_('select.genericlist', $aEls, $name, $attribs, 'value', 'text', $default);
 	}
 


### PR DESCRIPTION
Avoid sorting array before returning it.

A couple of small code simplifications.

Cast valueformat to string like other variables are cast.
