### PR TITLE
Fix php notice in element.php

### DIFF
--- a/components/com_fabrik/models/element.php
+++ b/components/com_fabrik/models/element.php
@@ -2797,7 +2797,7 @@ class PlgFabrik_Element extends FabrikPlugin
 			case 'hidden':
 				if (is_array($default))
 				{
-					$this->rangedFilterFields($default, $return, $rows, $v, 'hidden');
+					$this->rangedFilterFields($default, $return, null, $v, 'hidden');
 				}
 				else
 				{


### PR DESCRIPTION
Get a php notice due to uninitialised variable.

$row replaced with null in call.
