### PR TITLE
Avoid empty div when button group is empty

### DIFF
--- a/components/com_fabrik/views/form/tmpl/bootstrap_tabs/default_actions.php
+++ b/components/com_fabrik/views/form/tmpl/bootstrap_tabs/default_actions.php
@@ -12,17 +12,17 @@ if ($this->hasActions) : ?>
 			?>
 			</div>
 		</div>
-
+		<?php if ($form->gobackButton . $form->resetButton . $form->deleteButton !== '') : ?>
 		<div class="span4">
 			<div class="btn-group">
 				<?php
 				echo $form->gobackButton  . ' ' . $this->message;
 				echo $form->resetButton . ' ';
-				echo  $form->deleteButton;
+				echo $form->deleteButton;
 				?>
 			</div>
 		</div>
+		<?php endif; ?>
 	</div>
 </div>
-<?php
-endif;
+<?php endif; ?>


### PR DESCRIPTION
Avoid empty div when none of back, reset and delete buttons are shown.
