### PR TITLE
Group outro output when empty

### DIFF
--- a/components/com_fabrik/views/form/tmpl/admin/default.php
+++ b/components/com_fabrik/views/form/tmpl/admin/default.php
@@ -72,7 +72,7 @@ echo "<div class=\"fabrikMainError fabrikError$active\">$form->error</div>";?>
 			echo $this->loadTemplate('group');
 		}
 	// Show the group outro
-	if ($group->outro !== '') :?>
+	if ($group->outro != '') :?>
 		<div class="groupoutro"><?php echo $group->outro ?></div>
 	<?php
 	endif;

--- a/components/com_fabrik/views/form/tmpl/bluesky/default.php
+++ b/components/com_fabrik/views/form/tmpl/bluesky/default.php
@@ -77,7 +77,7 @@ echo "$form->error</div>";?>
 			$this->elements = $group->elements;
 			echo $this->loadTemplate('group');
 		}	// Show the group outro
-	if ($group->outro !== '') :?>
+	if ($group->outro != '') :?>
 		<div class="groupoutro"><?php echo $group->outro ?></div>
 	<?php
 	endif;

--- a/components/com_fabrik/views/form/tmpl/default/default.php
+++ b/components/com_fabrik/views/form/tmpl/default/default.php
@@ -119,7 +119,7 @@ foreach ($this->groups as $group) :
 	$this->elements = $group->elements;
 	echo $this->loadTemplate($group->tmpl);
 	// Show the group outro
-	if ($group->outro !== '') :?>
+	if ($group->outro != '') :?>
 		<div class="groupoutro"><?php echo $group->outro ?></div>
 	<?php
 	endif;

--- a/components/com_fabrik/views/form/tmpl/default_rounded/default.php
+++ b/components/com_fabrik/views/form/tmpl/default_rounded/default.php
@@ -76,7 +76,7 @@ echo "$form->error</div>";?>
 		} else {
 			$this->elements = $group->elements;
 			echo $this->loadTemplate('group');
-		}	// Show the group outro	if ($group->outro !== '') :?>		<div class="groupoutro"><?php echo $group->outro ?></div>	<?php	endif;	?>	
+		}	// Show the group outro	if ($group->outro != '') :?>		<div class="groupoutro"><?php echo $group->outro ?></div>	<?php	endif;	?>	
 	</fieldset>
 <?php
 	}

--- a/components/com_fabrik/views/form/tmpl/default_rtl/default.php
+++ b/components/com_fabrik/views/form/tmpl/default_rtl/default.php
@@ -77,7 +77,7 @@ echo "$form->error</div>";?>
 			$this->elements = $group->elements;
 			echo $this->loadTemplate('group');
 		}	// Show the group outro
-	if ($group->outro !== '') :?>
+	if ($group->outro != '') :?>
 		<div class="groupoutro"><?php echo $group->outro ?></div>
 	<?php
 	endif;

--- a/components/com_fabrik/views/form/tmpl/f3/default.php
+++ b/components/com_fabrik/views/form/tmpl/f3/default.php
@@ -78,7 +78,7 @@ echo "$form->error</div>";?>
 			$this->elements = $group->elements;
 			echo $this->loadTemplate('group');
 		}	// Show the group outro
-	if ($group->outro !== '') :?>
+	if ($group->outro != '') :?>
 		<div class="groupoutro"><?php echo $group->outro ?></div>
 	<?php
 	endif;

--- a/components/com_fabrik/views/form/tmpl/iwebkit/default.php
+++ b/components/com_fabrik/views/form/tmpl/iwebkit/default.php
@@ -164,7 +164,7 @@ echo "<div class=\"fabrikMainError fabrikError$active\">$form->error</div>";?>
 			$this->elements = $group->elements;
 			echo $this->loadTemplate('group');
 		}	// Show the group outro
-	if ($group->outro !== '') :?>
+	if ($group->outro != '') :?>
 		<div class="groupoutro"><?php echo $group->outro ?></div>
 	<?php
 	endif;

--- a/components/com_fabrik/views/form/tmpl/labels-above/default.php
+++ b/components/com_fabrik/views/form/tmpl/labels-above/default.php
@@ -82,7 +82,7 @@ echo "$form->error</div>";?>
 			$this->elements = $group->elements;
 			echo $this->loadTemplate('group');
 		}	// Show the group outro
-	if ($group->outro !== '') :?>
+	if ($group->outro != '') :?>
 		<div class="groupoutro"><?php echo $group->outro ?></div>
 	<?php
 	endif;

--- a/components/com_fabrik/views/form/tmpl/mint/default.php
+++ b/components/com_fabrik/views/form/tmpl/mint/default.php
@@ -77,7 +77,7 @@ echo "$form->error</div>";?>
 			$this->elements = $group->elements;
 			echo $this->loadTemplate('group');
 		}	// Show the group outro
-	if ($group->outro !== '') :?>
+	if ($group->outro != '') :?>
 		<div class="groupoutro"><?php echo $group->outro ?></div>
 	<?php
 	endif;

--- a/components/com_fabrik/views/form/tmpl/no-labels/default.php
+++ b/components/com_fabrik/views/form/tmpl/no-labels/default.php
@@ -78,7 +78,7 @@ echo "$form->error</div>";?>
 			echo $this->loadTemplate('group');
 		}
 	// Show the group outro
-	if ($group->outro !== '') :?>
+	if ($group->outro != '') :?>
 		<div class="groupoutro"><?php echo $group->outro ?></div>
 	<?php
 	endif;

--- a/components/com_fabrik/views/form/tmpl/tabs/default.php
+++ b/components/com_fabrik/views/form/tmpl/tabs/default.php
@@ -83,7 +83,7 @@ $this->group = $group;
 					$this->elements = $subgroup;
 					echo $this->loadTemplate($group->tmpl);
 	// Show the group outro
-	if ($group->outro !== '') :?>		<div class="groupoutro"><?php echo $group->outro ?></div>
+	if ($group->outro != '') :?>		<div class="groupoutro"><?php echo $group->outro ?></div>
 	<?php
 	endif;
 	?>					?>
@@ -115,7 +115,7 @@ $this->group = $group;
 		$this->elements = $group->elements;
 		echo $this->loadTemplate($group->tmpl);
 		// Show the group outro
-		if ($group->outro !== '') :?>
+		if ($group->outro != '') :?>
 			<div class="groupoutro"><?php echo $group->outro ?></div>
 <?php
 		endif;


### PR DESCRIPTION
($group->outro !== '') caused the outro to be output when outro is null.  Replaced with ($group->outro != '').
