### PR TITLE
J3/Bootstrap use hasTootip rather than hasTip

### DIFF
--- a/administrator/components/com_fabrik/classes/31/field.php
+++ b/administrator/components/com_fabrik/classes/31/field.php
@@ -520,7 +520,7 @@ abstract class JFormField
 		$text = $this->translateLabel ? JText::_($text) : $text;
 
 		// Build the class for the label.
-		$class = !empty($this->description) ? 'hasTip' : '';
+		$class = !empty($this->description) ? 'hasTooltip' : '';
 		$class = $this->required == true ? $class . ' required' : $class;
 		$class = !empty($this->labelClass) ? $class . ' ' . $this->labelClass : $class;
 

--- a/administrator/components/com_fabrik/views/home/tmpl/bootstrap.php
+++ b/administrator/components/com_fabrik/views/home/tmpl/bootstrap.php
@@ -97,7 +97,7 @@ JToolBarHelper::title(JText::_('COM_FABRIK_WELCOME'), 'fabrik.png');
 								<?php echo $log->timedate_created;?>
 								</td>
 								<td>
-								<span class="editlinktip hasTip" title="<?php echo $log->message_type . "::" . $log->message; ?>">
+								<span class="editlinktip hasTooltip" title="<?php echo $log->message_type . "::" . $log->message; ?>">
 									<?php echo $log->message_type;?>
 								</span>
 								</td>

--- a/administrator/components/com_fabrik/views/lists/tmpl/bootstrap.php
+++ b/administrator/components/com_fabrik/views/lists/tmpl/bootstrap.php
@@ -106,12 +106,12 @@ $listDirn	= $this->state->get('list.direction');
 				<td>
 					<?php
 					if ($item->checked_out && ( $item->checked_out != $user->get('id'))) : ?>
-					<span class="editlinktip hasTip"
+					<span class="editlinktip hasTooltip"
 						title="<?php echo $item->label . "::" . $params->get('note'); ?>"> <?php echo $item->label; ?>
 					</span>
 					<?php else : ?>
 					<a href="<?php echo $link;?>">
-						<span class="editlinktip hasTip" title="<?php echo $item->label . "::" . $params->get('note'); ?>">
+						<span class="editlinktip hasTooltip" title="<?php echo $item->label . "::" . $params->get('note'); ?>">
 							<?php echo $item->label; ?>
 						</span>
 					</a>


### PR DESCRIPTION
This was not the cause of my disappearing fields problem which was the T3 framework providing an updated - but broken for Joomla - Bootstrap version. However it is recommended that in J3 you use hasTooltip rather than hasTip.

This PR changes use of hasTip in things that are obviously J3 / bootstrap (and leaves the rest as they are).
