### PR TITLE
Fixing join table aliases mismatch (J2.5/F3.0)

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -2106,12 +2106,14 @@ $groupBy .= '_raw';
 						{
 							$v = str_replace('`', '', $tmpPks[$pk][0]);
 							$v = explode('.', $v);
-							$v[0] = $v[0] . '_0';
+							// $v[0] = $v[0] . '_0';
 							$tmpPks[$pk][0] = $db->quoteName($v[0] . '.' . $v[1]);
 						}
 						$v = str_replace('`', '', $pk);
 						$v = explode('.', $v);
-						$v[0] = $v[0] . '_' . count($tmpPks[$pk]);
+						// Jaanus: commenting out $v[0] = $v[0] . '_0' and adding -1 to the count below 
+						// makes join aliases generated here match the aliases generated under _makeJoinAliases()
+						$v[0] = $v[0] . '_' . (count($tmpPks[$pk]) - 1); 
 						$tmpPks[$pk][] = $db->quoteName($v[0] . '.' . $v[1]);
 					}
 				}


### PR DESCRIPTION
This fix makes the join aliases generated under _buildQuery() match the aliases generated under _makeJoinAliases(). The mismatching in numeration used in aliases occurred when one table was used twice or more times as joined table. Example:

xtest_manytoone_one was used 3 times as joined table (different "from" tables); 
when in the __pkval part of the query its aliases were 
`xtest_manytoone_one_0`.`id` AS __pk_val2, 
`xtest_manytoone_one_1`.`id` AS __pk_val3, 
`xtest_manytoone_one_2`.`id` AS __pk_val4, 

then in "LEFT JOIN" part its aliases were
LEFT JOIN `xtest_manytoone_one` AS `xtest_manytoone_one` 
            ON `xtest_manytoone_one`.`xtest_manytoone_main_id` = `xtest_manytoone_main`.`id` 
LEFT JOIN `xtest_manytoone_one` AS `xtest_manytoone_one_0` 
            ON `xtest_manytoone_one_0`.`xtest_manytoone_1_id` = `xtest_manytoone_1`.`id` 
LEFT JOIN `xtest_manytoone_one` AS `xtest_manytoone_one_1` 
            ON `xtest_manytoone_one_1`.`xtest_manytoone_3_id` = `xtest_manytoone_3`.`id` 

and instead displaying list the sql error was displayed as xtest_manytoone_one_2 didn't actually exist.

This change DOESN'T fix another issue that when one table was joined many times then no all joined data is displayed. Another list and form with "daisy chain" table joins works like earlier (there just each joined table is used once, like usually).
