### PR TITLE
Simplify defines

### DIFF
--- a/plugins/system/fabrik/defines.php
+++ b/plugins/system/fabrik/defines.php
@@ -20,9 +20,9 @@ if (!JFolder::exists(JPATH_SITE . '/components/com_fabrik/'))
 	return;
 }
 
-define("COM_FABRIK_BASE", str_replace(DIRECTORY_SEPARATOR . 'administrator', '', JPATH_BASE) . DIRECTORY_SEPARATOR);
+define("COM_FABRIK_BASE", JPATH_SITE . DIRECTORY_SEPARATOR);
 define("COM_FABRIK_FRONTEND", COM_FABRIK_BASE . 'components/com_fabrik');
-define("COM_FABRIK_LIVESITE", str_replace('/administrator', '', JURI::base()));
+define("COM_FABRIK_LIVESITE", JURI::root());
 define("COM_FABRIK_LIVESITE_ROOT", JURI::getInstance()->toString(array('scheme', 'host', 'port')));
 define("FABRIKFILTER_TEXT", 0);
 define("FABRIKFILTER_EVAL", 1);


### PR DESCRIPTION
Change to use better Joomla calls which have true root and avoid removing /administrator (which may have been changed by some J security extensions).
