### PR TITLE
Add copyright to en gb.ini

### DIFF
--- a/administrator/components/com_fabrik/language/en-GB/en-GB.com_fabrik.ini
+++ b/administrator/components/com_fabrik/language/en-GB/en-GB.com_fabrik.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 COM_FABRIK_TIP_FX_DESC="The type of animation see http://mootools.net/docs/core/Fx/Fx"

--- a/administrator/components/com_fabrik/language/en-GB/en-GB.com_fabrik.sys.ini
+++ b/administrator/components/com_fabrik/language/en-GB/en-GB.com_fabrik.sys.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 COM_FABRIK_CONNECTIONS="Connections"

--- a/administrator/modules/mod_fabrik_quickicon/language/en-GB/en-GB.mod_fabrik_quickicon.ini
+++ b/administrator/modules/mod_fabrik_quickicon/language/en-GB/en-GB.mod_fabrik_quickicon.ini
@@ -1,7 +1,7 @@
-; 
 ; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
+; Note : All ini files need to be saved as UTF-8 - No BOM
 
 MOD_FABRIK_QUICKICON_LISTS="Lists"
 MOD_FABRIK_QUICKICON_FORMS="Forms"

--- a/administrator/modules/mod_fabrik_quickicon/language/en-GB/en-GB.mod_fabrik_quickicon.sys.ini
+++ b/administrator/modules/mod_fabrik_quickicon/language/en-GB/en-GB.mod_fabrik_quickicon.sys.ini
@@ -1,7 +1,7 @@
-; 
-; Fabrik 3 Quickicon Module
-; Copyright (C) 2005 - 2013 Fabrik. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
+; Note : All ini files need to be saved as UTF-8 - No BOM
 
 MOD_FABRIK_QUICKICON="Fabrik quick icon"
 MOD_FABRIK_QUICKICON_XML_DESCRIPTION="Adds quick icon buttons to your administration control panel"

--- a/modules/mod_fabrik_form/language/en-GB/en-GB.mod_fabrik_form.ini
+++ b/modules/mod_fabrik_form/language/en-GB/en-GB.mod_fabrik_form.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 MOD_FABRIK_FORM="Fabrik Form Module"

--- a/modules/mod_fabrik_form/language/en-GB/en-GB.mod_fabrik_form.sys.ini
+++ b/modules/mod_fabrik_form/language/en-GB/en-GB.mod_fabrik_form.sys.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 MOD_FABRIK_FORM="Fabrik Form Module"

--- a/modules/mod_fabrik_list/language/en-GB/en-GB.mod_fabrik_list.ini
+++ b/modules/mod_fabrik_list/language/en-GB/en-GB.mod_fabrik_list.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 MOD_FABRIK_LIST="Fabrik List Module"
@@ -46,11 +45,9 @@ MOD_FABRIK_LIST_TEMPLATE_DESC="The list template to use. Leave blank to use defa
 MOD_FABRIK_LIST_TEXT="Text"
 MOD_FABRIK_LIST_TYPE="Type"
 MOD_FABRIK_LIST_ELEMENTS_LABEL="Elements"
-
 MOD_FABRIK_LIST_QUERY="Query"
 MOD_FABRIK_LIST_SHOW_LIST_NAV_DESC="Show the pagination at the list bottom"
 MOD_FABRIK_LIST_SHOW_LIST_NAV_LABEL="Show pagination"
 MOD_FABRIK_LIST_XML_DESCRIPTION="This module shows a Fabrik list."
-
 COM_MODULES_list_elements_modal_FIELDSET_LABEL="Ignore me"
 COM_MODULES_order_by_FIELDSET_LABEL="Ignore me"

--- a/modules/mod_fabrik_list/language/en-GB/en-GB.mod_fabrik_list.sys.ini
+++ b/modules/mod_fabrik_list/language/en-GB/en-GB.mod_fabrik_list.sys.ini
@@ -1,9 +1,7 @@
-; 
 ; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 MOD_FABRIK_LIST="Fabrik List Module"
 MOD_FABRIK_LIST_XML_DESCRIPTION="This module shows a Fabrik list."
-

--- a/plugins/fabrik_cron/email/language/en-GB/en-GB.plg_fabrik_cron_email.ini
+++ b/plugins/fabrik_cron/email/language/en-GB/en-GB.plg_fabrik_cron_email.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005-2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_CRON_EMAIL_EVAL_LABEL="Eval"

--- a/plugins/fabrik_cron/email/language/en-GB/en-GB.plg_fabrik_cron_email.sys.ini
+++ b/plugins/fabrik_cron/email/language/en-GB/en-GB.plg_fabrik_cron_email.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_CRON_EMAIL="Fabrik Cron - Email"

--- a/plugins/fabrik_cron/gcalsync/language/en-GB/en-GB.plg_fabrik_cron_gcalsync.ini
+++ b/plugins/fabrik_cron/gcalsync/language/en-GB/en-GB.plg_fabrik_cron_gcalsync.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005-2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_CRON_GCAL_UPLOAD_LABEL="Sync to GCal"

--- a/plugins/fabrik_cron/gcalsync/language/en-GB/en-GB.plg_fabrik_cron_gcalsync.sys.ini
+++ b/plugins/fabrik_cron/gcalsync/language/en-GB/en-GB.plg_fabrik_cron_gcalsync.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_CRON_GCALSYNC="Fabrik Cron - GCal Sync"

--- a/plugins/fabrik_cron/geocode/language/en-GB/en-GB.plg_fabrik_cron_geocode.ini
+++ b/plugins/fabrik_cron/geocode/language/en-GB/en-GB.plg_fabrik_cron_geocode.ini
@@ -1,7 +1,7 @@
 ;
-; Fabrik 3 
+; Fabrik 3
 ; Copyright (C) 2005-2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_CRON_GEOCODE_GMAP_KEY_LABEL="Gmap Key"

--- a/plugins/fabrik_cron/geocode/language/en-GB/en-GB.plg_fabrik_cron_geocode.sys.ini
+++ b/plugins/fabrik_cron/geocode/language/en-GB/en-GB.plg_fabrik_cron_geocode.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_CRON_GEOCODE="Fabrik Cron - Geocode"

--- a/plugins/fabrik_cron/gmail/language/en-GB/en-GB.plg_fabrik_cron_gmail.ini
+++ b/plugins/fabrik_cron/gmail/language/en-GB/en-GB.plg_fabrik_cron_gmail.ini
@@ -1,7 +1,7 @@
 ;
 ; Fabrik 3.0
 ; Copyright (C) 2005-2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_CRON_GMAIL_EMAIL_LABEL="Email"

--- a/plugins/fabrik_cron/gmail/language/en-GB/en-GB.plg_fabrik_cron_gmail.sys.ini
+++ b/plugins/fabrik_cron/gmail/language/en-GB/en-GB.plg_fabrik_cron_gmail.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_CRON_GMAIL="Fabrik Cron - Gmail"

--- a/plugins/fabrik_cron/importcsv/language/en-GB/en-GB.plg_fabrik_cron_importcsv.ini
+++ b/plugins/fabrik_cron/importcsv/language/en-GB/en-GB.plg_fabrik_cron_importcsv.ini
@@ -1,7 +1,7 @@
 ;
-; Fabrik 3 
+; Fabrik 3
 ; Copyright (C) 2005-2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_CRON_IMPORTCSV_DELETEFILE="Delete File"

--- a/plugins/fabrik_cron/importcsv/language/en-GB/en-GB.plg_fabrik_cron_importcsv.sys.ini
+++ b/plugins/fabrik_cron/importcsv/language/en-GB/en-GB.plg_fabrik_cron_importcsv.sys.ini
@@ -1,7 +1,7 @@
 ;
-; Fabrik 3 
+; Fabrik 3
 ; Copyright (C) 2005-2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_CRON_IMPORTCSV="Fabrik Cron - ImportCSV"

--- a/plugins/fabrik_cron/notification/language/en-GB/en-GB.plg_fabrik_cron_notification.ini
+++ b/plugins/fabrik_cron/notification/language/en-GB/en-GB.plg_fabrik_cron_notification.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 FABRIK_NOTIFICATION_EMAIL="<p>Hi %s</p><p>Below is a summary of recent activity you have opted to follow:</p>"

--- a/plugins/fabrik_cron/notification/language/en-GB/en-GB.plg_fabrik_cron_notification.sys.ini
+++ b/plugins/fabrik_cron/notification/language/en-GB/en-GB.plg_fabrik_cron_notification.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_CRON_NOTIFICATIONS="Fabrik Cron - Notifications"

--- a/plugins/fabrik_cron/php/language/en-GB/en-GB.plg_fabrik_cron_php.ini
+++ b/plugins/fabrik_cron/php/language/en-GB/en-GB.plg_fabrik_cron_php.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005-2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_CRON_PHP_FILE_LABEL="PHP Script"

--- a/plugins/fabrik_cron/php/language/en-GB/en-GB.plg_fabrik_cron_php.sys.ini
+++ b/plugins/fabrik_cron/php/language/en-GB/en-GB.plg_fabrik_cron_php.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_CRON_PHP="Fabrik Cron - Run PHP"

--- a/plugins/fabrik_cron/rest/language/en-GB/en-GB.plg_fabrik_cron_rest.ini
+++ b/plugins/fabrik_cron/rest/language/en-GB/en-GB.plg_fabrik_cron_rest.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005-2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_CRON_REST_ENDPOINT_DESC="End point"

--- a/plugins/fabrik_cron/rest/language/en-GB/en-GB.plg_fabrik_cron_rest.sys.ini
+++ b/plugins/fabrik_cron/rest/language/en-GB/en-GB.plg_fabrik_cron_rest.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_CRON_REST="Fabrik Cron - REST"

--- a/plugins/fabrik_element/access/language/en-GB/en-GB.plg_fabrik_element_access.sys.ini
+++ b/plugins/fabrik_element/access/language/en-GB/en-GB.plg_fabrik_element_access.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_ACCESS="Fabrik Element - Access"

--- a/plugins/fabrik_element/birthday/language/en-GB/en-GB.plg_fabrik_element_birthday.ini
+++ b/plugins/fabrik_element/birthday/language/en-GB/en-GB.plg_fabrik_element_birthday.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_BIRTHDAY_DAY_LABEL="Day label"

--- a/plugins/fabrik_element/birthday/language/en-GB/en-GB.plg_fabrik_element_birthday.sys.ini
+++ b/plugins/fabrik_element/birthday/language/en-GB/en-GB.plg_fabrik_element_birthday.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_BIRTHDAY="Fabrik Element - Birthday"

--- a/plugins/fabrik_element/button/language/en-GB/en-GB.plg_fabrik_element_button.sys.ini
+++ b/plugins/fabrik_element/button/language/en-GB/en-GB.plg_fabrik_element_button.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_BUTTON="Fabrik Element - Button"

--- a/plugins/fabrik_element/calc/language/en-GB/en-GB.plg_fabrik_element_calc.ini
+++ b/plugins/fabrik_element/calc/language/en-GB/en-GB.plg_fabrik_element_calc.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrikar.com
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_CALC_AJAX_DESC="When set to yes, the element will observe any placeholders found in the 'Calculation' field and when those element's values are changed, will trigger an ajax call to perform the calculation on the server and update this element's value with the returned value."

--- a/plugins/fabrik_element/calc/language/en-GB/en-GB.plg_fabrik_element_calc.sys.ini
+++ b/plugins/fabrik_element/calc/language/en-GB/en-GB.plg_fabrik_element_calc.sys.ini
@@ -1,8 +1,8 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_CALC="Fabrik Element - Calculation"
 PLG_ELEMENT_CALC_HELP_SERVER="http://fabrikar.com/forums/index.php?wiki/calculation-element/"
-PLG_ELEMENT_CALC_DESCRIPTION="Performs calculations on result data, use {name} to access result data. "
+PLG_ELEMENT_CALC_DESCRIPTION="Performs calculations on result data, use {name} to access result data."

--- a/plugins/fabrik_element/captcha/language/en-GB/en-GB.plg_fabrik_element_captcha.ini
+++ b/plugins/fabrik_element/captcha/language/en-GB/en-GB.plg_fabrik_element_captcha.ini
@@ -1,14 +1,12 @@
-; 
-; Joomla! Project
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_CAPTCHA_SHOW_WHEN_LOGGED_IN_LABEL="Show when logged in?"
 PLG_ELEMENT_CAPTCHA_SHOW_WHEN_LOGGED_IN_DESC="If no selected and the user logged in, then the captcha is not shown on the form and is not validated"
 PLG_ELEMENT_CAPTCHA_METHOD_LABEL="Method"
 PLG_ELEMENT_CAPTCHA_METHOD_DESC="The standard method generates an image on the server which requires validation. The recaptcha method uses the recaptcha service to generate the captcha http://www.google.com/recaptcha"
-
 PLG_ELEMENT_STANDARD_CAPTCHA_FIELDSET_LABEL="Standard captcha options"
 PLG_ELEMENT_CAPTCHA_ANGLE_LABEL="Text Angle"
 PLG_ELEMENT_CAPTCHA_FONT_SIZE_LABEL="Font Size"
@@ -19,7 +17,6 @@ PLG_ELEMENT_CAPTCHA_NUMBER_OF_CHARS_LABEL="Num of chars"
 PLG_ELEMENT_CAPTCHA_BACKGROUND_COLOR="Background colour"
 PLG_ELEMENT_CAPTCHA_NOISE_COLOR="Noise colour"
 PLG_ELEMENT_CAPTCHA_TEXT_COLOR="Text colour"
-
 PLG_ELEMENT_RECAPTCHA_CAPTCHA_FIELDSET_LABEL="Recaptcha options"
 PLG_ELEMENT_CAPTCHA_RECAPTCHA_PUBLIC_KEY_LABEL="Public key"
 PLG_ELEMENT_CAPTCHA_RECAPTCHA_PUBLIC_KEY_DESC="Get your public key from http://www.google.com/recaptcha"
@@ -29,12 +26,10 @@ PLG_ELEMENT_CAPTCHA_FAILED="Please ensure that you have entered text matching th
 PLG_ELEMENT_RECAPTCHA_SETTINGS="Recaptcha settings"
 PLG_ELEMENT_STANDARD_SETTINGS="Standard settings"
 PLG_ELEMENT_CAPTCHA_WARN_FREETYPE="Your version of PHP needs to be compiled with Freetype support to use CAPTCHA"
-
 PLG_ELEMENT_RECAPTCHA_THEME="Theme"
 PLG_ELEMENT_RECAPTCHA_THEME_DESC="Choose the theme to use to change the way the recaptcha box looks"
 PLG_ELEMENT_RECAPTCHA_LANG="Lang"
 PLG_ELEMENT_RECAPTCHA_LANG_DESC="Enter the 2 letter code of the language to use for the recaptcha widget - default/empty = English. - Available languages: en, nl, fr, de, pt, ru, es, tr"
-
 PLG_ELEMENT_CAPTCHA_PLAYTHRU_FIELDSET_LABEL="PlayThru options"
 PLG_ELEMENT_CAPTCHA_PLAYTHRU_PUBLISHER_KEY_DESC="Get your PlayThru keys from http://areyouahuman.com"
 PLG_ELEMENT_CAPTCHA_PLAYTHRU_PUBLISHER_KEY_LABEL="Publisher Key"
@@ -42,5 +37,4 @@ PLG_ELEMENT_CAPTCHA_PLAYTHRU_SCORING_KEY_DESC="Get your PlayThru keys from http:
 PLG_ELEMENT_CAPTCHA_PLAYTHRU_SCORING_KEY_LABEL="Scoring Key"
 
 ;FRONT END
-
 PLG_ELEMENT_CAPTCHA_FAILED="Incorrect text entered"

--- a/plugins/fabrik_element/captcha/language/en-GB/en-GB.plg_fabrik_element_captcha.sys.ini
+++ b/plugins/fabrik_element/captcha/language/en-GB/en-GB.plg_fabrik_element_captcha.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_CAPTCHA="Fabrik Element - Captcha"

--- a/plugins/fabrik_element/cascadingdropdown/language/en-GB/en-GB.plg_fabrik_element_cascadingdropdown.ini
+++ b/plugins/fabrik_element/cascadingdropdown/language/en-GB/en-GB.plg_fabrik_element_cascadingdropdown.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrik 2.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_CDD_AUTOCOMPLETE="Autocomplete"

--- a/plugins/fabrik_element/cascadingdropdown/language/en-GB/en-GB.plg_fabrik_element_cascadingdropdown.sys.ini
+++ b/plugins/fabrik_element/cascadingdropdown/language/en-GB/en-GB.plg_fabrik_element_cascadingdropdown.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_CASCADINGDROPDOWN="Fabrik Element - Cascading dropdown"

--- a/plugins/fabrik_element/checkbox/language/en-GB/en-GB.plg_fabrik_element_checkbox.ini
+++ b/plugins/fabrik_element/checkbox/language/en-GB/en-GB.plg_fabrik_element_checkbox.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrikar.com
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_CHECKBOX_ALLOW_ADD_DESC="If yes, then in the front end the user can add options to the checkboxes list"

--- a/plugins/fabrik_element/checkbox/language/en-GB/en-GB.plg_fabrik_element_checkbox.sys.ini
+++ b/plugins/fabrik_element/checkbox/language/en-GB/en-GB.plg_fabrik_element_checkbox.sys.ini
@@ -1,12 +1,11 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_CHECKBOX="Fabrik Element - Checkbox"
 PLG_ELEMENT_CHECKBOX_HELP_SERVER="http://fabrikar.com/forums/index.php?wiki/checkbox-element/"
 PLG_ELEMENT_CHECKBOX_DESCRIPTION="Renders Checkbox element"
-
 PLG_ELEMENT_FABRIK_OPTIONS="Options"
 PLG_ELEMENT_FABRIK_FIELD_TYPE_LABEL="Field type"
 PLG_ELEMENT_FABRIK_FIELD_TYPE_DESC="The database field type used when creating the element"

--- a/plugins/fabrik_element/colourpicker/language/en-GB/en-GB.plg_fabrik_element_colourpicker.ini
+++ b/plugins/fabrik_element/colourpicker/language/en-GB/en-GB.plg_fabrik_element_colourpicker.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrikar.com
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_COLOURPICKER_SWATCH_LABEL="Swatch"

--- a/plugins/fabrik_element/colourpicker/language/en-GB/en-GB.plg_fabrik_element_colourpicker.sys.ini
+++ b/plugins/fabrik_element/colourpicker/language/en-GB/en-GB.plg_fabrik_element_colourpicker.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_COLOURPICKER="Fabrik Element - Colour Picker"

--- a/plugins/fabrik_element/count/language/en-GB/en-GB.plg_fabrik_element_count.ini
+++ b/plugins/fabrik_element/count/language/en-GB/en-GB.plg_fabrik_element_count.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_COUNT_FIELD_LABEL="Count field"

--- a/plugins/fabrik_element/count/language/en-GB/en-GB.plg_fabrik_element_count.sys.ini
+++ b/plugins/fabrik_element/count/language/en-GB/en-GB.plg_fabrik_element_count.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_COUNT="Fabrik Element - Count"

--- a/plugins/fabrik_element/databasejoin/language/en-GB/en-GB.plg_fabrik_element_databasejoin.ini
+++ b/plugins/fabrik_element/databasejoin/language/en-GB/en-GB.plg_fabrik_element_databasejoin.ini
@@ -1,7 +1,6 @@
-;
-; Fabrikar.com
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 COM_FABRIK_NO_POPUP_FORMS_AVAILABLE="No linked forms found"

--- a/plugins/fabrik_element/databasejoin/language/en-GB/en-GB.plg_fabrik_element_databasejoin.sys.ini
+++ b/plugins/fabrik_element/databasejoin/language/en-GB/en-GB.plg_fabrik_element_databasejoin.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_DATABASEJOIN="Fabrik Element - Database Join"

--- a/plugins/fabrik_element/date/language/en-GB/en-GB.plg_fabrik_element_date.ini
+++ b/plugins/fabrik_element/date/language/en-GB/en-GB.plg_fabrik_element_date.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrikar.com
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_WIDTH_LABEL="Width"

--- a/plugins/fabrik_element/date/language/en-GB/en-GB.plg_fabrik_element_date.sys.ini
+++ b/plugins/fabrik_element/date/language/en-GB/en-GB.plg_fabrik_element_date.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_DATE="Fabrik Element - Date"

--- a/plugins/fabrik_element/display/language/en-GB/en-GB.plg_fabrik_element_display.ini
+++ b/plugins/fabrik_element/display/language/en-GB/en-GB.plg_fabrik_element_display.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrikar.com
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_DISPLAY_EVAL_LABEL="Eval"

--- a/plugins/fabrik_element/display/language/en-GB/en-GB.plg_fabrik_element_display.sys.ini
+++ b/plugins/fabrik_element/display/language/en-GB/en-GB.plg_fabrik_element_display.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_DISPLAY="Fabrik Element - Display Text"

--- a/plugins/fabrik_element/dropdown/language/en-GB/en-GB.plg_fabrik_element_dropdown.ini
+++ b/plugins/fabrik_element/dropdown/language/en-GB/en-GB.plg_fabrik_element_dropdown.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrikar.com
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_DROPDOWN_ALLOW_MULTISELECT_LABEL="Multiple selections"

--- a/plugins/fabrik_element/dropdown/language/en-GB/en-GB.plg_fabrik_element_dropdown.sys.ini
+++ b/plugins/fabrik_element/dropdown/language/en-GB/en-GB.plg_fabrik_element_dropdown.sys.ini
@@ -1,11 +1,10 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_DROPDOWN="Fabrik Element - Dropdown"
 PLG_ELEMENT_DROPDOWN_DESCRIPTION="Renders Drop down / multiple select box"
-
 PLG_ELEMENT_DROPDOWN_HELP_SERVER="http://fabrikar.com/forums/index.php?wiki/dropdown-element/"
 PLG_ELEMENT_FABRIK_OPTIONS="Options"
 PLG_ELEMENT_FABRIK_FIELD_TYPE_LABEL="Field type"

--- a/plugins/fabrik_element/fbactivityfeed/language/en-GB/en-GB.plg_fabrik_element_fbactivityfeed.ini
+++ b/plugins/fabrik_element/fbactivityfeed/language/en-GB/en-GB.plg_fabrik_element_fbactivityfeed.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_FBFEED_APPLICATION_ID_LABEL="Application ID"

--- a/plugins/fabrik_element/fbactivityfeed/language/en-GB/en-GB.plg_fabrik_element_fbactivityfeed.sys.ini
+++ b/plugins/fabrik_element/fbactivityfeed/language/en-GB/en-GB.plg_fabrik_element_fbactivityfeed.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_FBACTIVITYFEED="Fabrik Element - Facebook activity feed"

--- a/plugins/fabrik_element/fbcomment/language/en-GB/en-GB.plg_fabrik_element_fbcomment.ini
+++ b/plugins/fabrik_element/fbcomment/language/en-GB/en-GB.plg_fabrik_element_fbcomment.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_FBCOMMENT_APPLICATION_ID_LABEL="Application ID"

--- a/plugins/fabrik_element/fbcomment/language/en-GB/en-GB.plg_fabrik_element_fbcomment.sys.ini
+++ b/plugins/fabrik_element/fbcomment/language/en-GB/en-GB.plg_fabrik_element_fbcomment.sys.ini
@@ -1,5 +1,6 @@
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_FBCOMMENT="Fabrik Element - Facebook comment"

--- a/plugins/fabrik_element/fblike/language/en-GB/en-GB.plg_fabrik_element_fblike.ini
+++ b/plugins/fabrik_element/fblike/language/en-GB/en-GB.plg_fabrik_element_fblike.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_FBLIKE_ACTION_LABEL="Action"

--- a/plugins/fabrik_element/fblike/language/en-GB/en-GB.plg_fabrik_element_fblike.sys.ini
+++ b/plugins/fabrik_element/fblike/language/en-GB/en-GB.plg_fabrik_element_fblike.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_FBLIKE="Fabrik Element - Facebook like button"

--- a/plugins/fabrik_element/fblikebox/language/en-GB/en-GB.plg_fabrik_element_fblikebox.ini
+++ b/plugins/fabrik_element/fblikebox/language/en-GB/en-GB.plg_fabrik_element_fblikebox.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_FBLIKEBOX_PAGE_ID_LABEL="Page ID"

--- a/plugins/fabrik_element/fblikebox/language/en-GB/en-GB.plg_fabrik_element_fblikebox.sys.ini
+++ b/plugins/fabrik_element/fblikebox/language/en-GB/en-GB.plg_fabrik_element_fblikebox.sys.ini
@@ -1,6 +1,6 @@
-;
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_FBLIKEBOX="Fabrik Element - Facebook like box"

--- a/plugins/fabrik_element/fbrecommendations/language/en-GB/en-GB.plg_fabrik_element_fbrecommendations.ini
+++ b/plugins/fabrik_element/fbrecommendations/language/en-GB/en-GB.plg_fabrik_element_fbrecommendations.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_FBRECOMMENDATION_APPLICATION_ID_LABEL="Application ID"

--- a/plugins/fabrik_element/fbrecommendations/language/en-GB/en-GB.plg_fabrik_element_fbrecommendations.sys.ini
+++ b/plugins/fabrik_element/fbrecommendations/language/en-GB/en-GB.plg_fabrik_element_fbrecommendations.sys.ini
@@ -1,6 +1,6 @@
-;
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_FBRECOMMENDATIONS="Fabrik Element - Facebook Recommendations"

--- a/plugins/fabrik_element/field/language/en-GB/en-GB.plg_fabrik_element_field.ini
+++ b/plugins/fabrik_element/field/language/en-GB/en-GB.plg_fabrik_element_field.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_FIELD_AUTOCOMPLETE_DESC="If set to yes then the browser will show the user previously entered values as options when typing. Note this does not do an AJAX look up to find data entered by other users"

--- a/plugins/fabrik_element/field/language/en-GB/en-GB.plg_fabrik_element_field.sys.ini
+++ b/plugins/fabrik_element/field/language/en-GB/en-GB.plg_fabrik_element_field.sys.ini
@@ -1,6 +1,6 @@
-;
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_FIELD="Fabrik Element - Field"

--- a/plugins/fabrik_element/fileupload/language/en-GB/en-GB.plg_fabrik_element_fileupload.ini
+++ b/plugins/fabrik_element/fileupload/language/en-GB/en-GB.plg_fabrik_element_fileupload.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrikar.com
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_FILEUPLOAD_ACCESS_IMG_LABEL="Access image"
@@ -25,7 +24,7 @@ PLG_ELEMENT_FILEUPLOAD_AMAZONS3_SECRETKEY_LABEL="Amazon s3 secret key "
 PLG_ELEMENT_FILEUPLOAD_AMAZONS3_STORAGE_LOCATION_DESC="Determine if you want to store your files in the USA or in Europe."
 PLG_ELEMENT_FILEUPLOAD_AMAZONS3_STORAGE_LOCATION_LABEL="Amazon storage location"
 PLG_ELEMENT_FILEUPLOAD_AMAZONS3_STORAGE_TITLE="Amazon storage options"
-PLG_ELEMENT_FILEUPLOAD_AJAX_CHUNK_SIZE_DESC="Defines if the file should be uploaded in 'chunks'. Set to 0 to upload the entire file in one go. Otherwise define an integer in Kb." 
+PLG_ELEMENT_FILEUPLOAD_AJAX_CHUNK_SIZE_DESC="Defines if the file should be uploaded in 'chunks'. Set to 0 to upload the entire file in one go. Otherwise define an integer in Kb."
 PLG_ELEMENT_FILEUPLOAD_AJAX_CHUNK_SIZE_LABEL="Chunk size"
 PLG_ELEMENT_FILEUPLOAD_AJAX_DESC="Allow for multiple uploads.  NOTE that this changes the way Fabrik stores your element data, so changing this selection once you have data in your table will lose any links to existing uploaded content"
 PLG_ELEMENT_FILEUPLOAD_AJAX_UPLOADS="Ajax uploads"
@@ -118,7 +117,7 @@ PLG_ELEMENT_FILEUPLOAD_SKIP_CHECK_DESC="Normally when rendering a file link in t
 PLG_ELEMENT_FILEUPLOAD_SKIP_CHECK_LABEL="Skip Exist Check"
 PLG_ELEMENT_FILEUPLOAD_SLIDESHOW="Slideshow"
 PLG_ELEMENT_FILEUPLOAD_SSL_DESC="Serve the documents/images over SSL"
-PLG_ELEMENT_FILEUPLOAD_SSL_LABEL="SSL" 
+PLG_ELEMENT_FILEUPLOAD_SSL_LABEL="SSL"
 PLG_ELEMENT_FILEUPLOAD_STORAGE="Storage"
 PLG_ELEMENT_FILEUPLOAD_TITLE_ELEMENT_DESC="If 'show media in form' or 'show media in the list view' selected then this element's data will be used as the image title inside the lightbox"
 PLG_ELEMENT_FILEUPLOAD_TITLE_ELEMENT_LABEL="Title element"
@@ -143,7 +142,6 @@ PLG_ELEMENT_FILEUPLOAD_WIN_WIDTH_LABEL="Crop window width"
 PLG_ELEMENT_FILEUPLOAD_WIN_HEIGHT_LABEL="Crop window height"
 
 ; Front end
-
 PLG_ELEMENT_FILEUPLOAD_ADD_FILES="Add files"
 PLG_ELEMENT_FILEUPLOAD_BY="By"
 PLG_ELEMENT_FILEUPLOAD_CROP_AND_SCALE="Crop and scale"

--- a/plugins/fabrik_element/fileupload/language/en-GB/en-GB.plg_fabrik_element_fileupload.sys.ini
+++ b/plugins/fabrik_element/fileupload/language/en-GB/en-GB.plg_fabrik_element_fileupload.sys.ini
@@ -1,6 +1,6 @@
-;
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_FILEUPLOAD="Fabrik Element - File Upload"

--- a/plugins/fabrik_element/folder/language/en-GB/en-GB.plg_fabrik_element_folder.ini
+++ b/plugins/fabrik_element/folder/language/en-GB/en-GB.plg_fabrik_element_folder.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_FOLDER_PATH_DESC="Path to root location of folder list (e.g. components/com_fabrik)"

--- a/plugins/fabrik_element/folder/language/en-GB/en-GB.plg_fabrik_element_folder.sys.ini
+++ b/plugins/fabrik_element/folder/language/en-GB/en-GB.plg_fabrik_element_folder.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_FOLDER="Fabrik Element - Folder"

--- a/plugins/fabrik_element/googlemap/language/en-GB/en-GB.plg_fabrik_element_googlemap.ini
+++ b/plugins/fabrik_element/googlemap/language/en-GB/en-GB.plg_fabrik_element_googlemap.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_GOOGLE_MAP_AS_YOU_TYPE="As you type"
@@ -24,7 +23,7 @@ PLG_ELEMENT_GOOGLE_MAP_GEOCODE_COUNTRY_DESC="The element on your form to use as 
 PLG_ELEMENT_GOOGLE_MAP_GEOCODE_COUNTRY_LABEL="Country"
 PLG_ELEMENT_GOOGLE_MAP_GEOCODE_DESC="If yes, inserts a field and button for typing and geocoding an address (in any format Google Geocoding supports), but the address itself is not stored with the form.  If set to Use Fields, the optional fields you specify below will be used for Geocoding the map, instead of a separate input field on the map."
 PLG_ELEMENT_GOOGLE_MAP_GEOCODE_EVENT_DESC="If button selected then the geocoding occurs when the 'geocode' button is pressed. If 'as you type' selected then there is no geo code button instead the geocoding occurs as the user types. Applies only when Enable Geocoding = 'yes', if 'use elements' selected the geocoding applies 'as you type'"
-PLG_ELEMENT_GOOGLE_MAP_GEOCODE_EVENT_LABEL="Trigger geocode with" 
+PLG_ELEMENT_GOOGLE_MAP_GEOCODE_EVENT_LABEL="Trigger geocode with"
 PLG_ELEMENT_GOOGLE_MAP_GEOCODE_LABEL="Enable Geocode"
 PLG_ELEMENT_GOOGLE_MAP_GEOCODE_STATE_DESC="The element on your form to use as State/Region, if Use Fields is specified for the Geocode option.  You should select as many of these fields as you need to build a complete comma separated address for Geocoding."
 PLG_ELEMENT_GOOGLE_MAP_GEOCODE_STATE_LABEL="State/Region"

--- a/plugins/fabrik_element/googlemap/language/en-GB/en-GB.plg_fabrik_element_googlemap.sys.ini
+++ b/plugins/fabrik_element/googlemap/language/en-GB/en-GB.plg_fabrik_element_googlemap.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_GOOGLEMAP="Fabrik Element - Google Map"

--- a/plugins/fabrik_element/googleometer/language/en-GB/en-GB.plg_fabrik_element_googleometer.sys.ini
+++ b/plugins/fabrik_element/googleometer/language/en-GB/en-GB.plg_fabrik_element_googleometer.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_GOOGLEOMETER="Fabrik Element - Google-O-Meter Charts"

--- a/plugins/fabrik_element/image/language/en-GB/en-GB.plg_fabrik_element_image.ini
+++ b/plugins/fabrik_element/image/language/en-GB/en-GB.plg_fabrik_element_image.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_IMAGE_USER_SEL_IMAGE_LABEL="Frontend select"

--- a/plugins/fabrik_element/image/language/en-GB/en-GB.plg_fabrik_element_image.sys.ini
+++ b/plugins/fabrik_element/image/language/en-GB/en-GB.plg_fabrik_element_image.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_IMAGE="Fabrik Element - Image"

--- a/plugins/fabrik_element/internalid/language/en-GB/en-GB.plg_fabrik_element_internalid.sys.ini
+++ b/plugins/fabrik_element/internalid/language/en-GB/en-GB.plg_fabrik_element_internalid.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_INTERNALID="Fabrik Element - Internal ID"

--- a/plugins/fabrik_element/ip/language/en-GB/en-GB.plg_fabrik_element_ip.ini
+++ b/plugins/fabrik_element/ip/language/en-GB/en-GB.plg_fabrik_element_ip.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrik 2.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_IP_HIDDEN_LABEL="Hidden"

--- a/plugins/fabrik_element/ip/language/en-GB/en-GB.plg_fabrik_element_ip.sys.ini
+++ b/plugins/fabrik_element/ip/language/en-GB/en-GB.plg_fabrik_element_ip.sys.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_IP="Fabrik Element - IP address"

--- a/plugins/fabrik_element/jsperiodical/language/en-GB/en-GB.plg_fabrik_element_jsperiodical.ini
+++ b/plugins/fabrik_element/jsperiodical/language/en-GB/en-GB.plg_fabrik_element_jsperiodical.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrikar.com
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_JSPERIODICAL_TIME_LABEL="Time"

--- a/plugins/fabrik_element/jsperiodical/language/en-GB/en-GB.plg_fabrik_element_jsperiodical.sys.ini
+++ b/plugins/fabrik_element/jsperiodical/language/en-GB/en-GB.plg_fabrik_element_jsperiodical.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_JSPERIODICAL="Fabrik Element - JSPeriodical"

--- a/plugins/fabrik_element/kaltura/language/en-GB/en-GB.plg_fabrik_element_kaltura.ini
+++ b/plugins/fabrik_element/kaltura/language/en-GB/en-GB.plg_fabrik_element_kaltura.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_KALTURA_PARTENER_ID_LABEL="Partner id"

--- a/plugins/fabrik_element/kaltura/language/en-GB/en-GB.plg_fabrik_element_kaltura.sys.ini
+++ b/plugins/fabrik_element/kaltura/language/en-GB/en-GB.plg_fabrik_element_kaltura.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_KALTURA="Fabrik Element - Kaltura Video Upload"

--- a/plugins/fabrik_element/link/language/en-GB/en-GB.plg_fabrik_element_link.ini
+++ b/plugins/fabrik_element/link/language/en-GB/en-GB.plg_fabrik_element_link.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_LINK_BITLY="Bitly"

--- a/plugins/fabrik_element/link/language/en-GB/en-GB.plg_fabrik_element_link.sys.ini
+++ b/plugins/fabrik_element/link/language/en-GB/en-GB.plg_fabrik_element_link.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_LINK="Fabrik Element - Link"

--- a/plugins/fabrik_element/notes/language/en-GB/en-GB.plg_fabrik_element_notes.ini
+++ b/plugins/fabrik_element/notes/language/en-GB/en-GB.plg_fabrik_element_notes.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_NOTES_CONNECTION_LABEL="Connection"
@@ -14,7 +13,6 @@ PLG_ELEMENT_NOTES_LABEL_DESC="This fields values will be used for the drop down 
 PLG_ELEMENT_NOTES_HIDDEN="Hidden"
 PLG_ELEMENT_NOTES_EVAL_LABEL="Eval"
 PLG_ELEMENT_NOTES_DEFAULT_LABEL="Default"
-
 PLG_ELEMENT_NOTES_FOREIGN_KEY_LABEL="Foreign Key"
 PLG_ELEMENT_NOTES_FOREIGN_KEY_DESC="The field in the notes table that will hold a reference to the form's row id/primary key"
 PLG_ELEMENT_NOTES_ORDER_FIELD_LABEL="Order by"
@@ -29,6 +27,5 @@ PLG_ELEMENT_NOTES_WHERE_VALUE_LABEL="Where value or statement"
 PLG_ELEMENT_NOTES_WHERE_VALUE_DESC="If 'where' field selected AND it's not the same as FK: which value the field must have to filter the displayed notes. Must not have quotes! e.g: value_1 <br />Otherwise: custom statement, e.g: (field_1 = 'value1' AND field_2 = 'value2') OR field_3 = 'value3' "
 
 ;FRONT END
-
 PLG_ELEMENT_NOTES_ADD="Add"
 PLG_ELEMENT_NOTES_SAVEFIRST="If this form is new, you can submit notes only after you have submitted form data"

--- a/plugins/fabrik_element/notes/language/en-GB/en-GB.plg_fabrik_element_notes.sys.ini
+++ b/plugins/fabrik_element/notes/language/en-GB/en-GB.plg_fabrik_element_notes.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_NOTES="Fabrik Element - Notes"

--- a/plugins/fabrik_element/openstreetmap/language/en-GB/en-GB.plg_fabrik_element_openstreetmap.sys.ini
+++ b/plugins/fabrik_element/openstreetmap/language/en-GB/en-GB.plg_fabrik_element_openstreetmap.sys.ini
@@ -1,8 +1,7 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
-; Note : All ini 
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
+; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_OPENSTREETMAP="Fabrik Element - Open Street Map"
 PLG_ELEMENT_OPENSTREETMAP_HELP_SERVER="http://fabrikar.com/forums/index.php?wiki/openstreetmap-element/"

--- a/plugins/fabrik_element/password/language/en-GB/en-GB.plg_fabrik_element_password.ini
+++ b/plugins/fabrik_element/password/language/en-GB/en-GB.plg_fabrik_element_password.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005-2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_PASSWORD_MAXLENGTH_LABEL="Field length"

--- a/plugins/fabrik_element/password/language/en-GB/en-GB.plg_fabrik_element_password.sys.ini
+++ b/plugins/fabrik_element/password/language/en-GB/en-GB.plg_fabrik_element_password.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_PASSWORD="Fabrik Element - Password"

--- a/plugins/fabrik_element/picklist/language/en-GB/en-GB.plg_fabrik_element_picklist.ini
+++ b/plugins/fabrik_element/picklist/language/en-GB/en-GB.plg_fabrik_element_picklist.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005-2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_PICKLIST_EDIT_DROPDOWN_LABEL="Add suboptions"

--- a/plugins/fabrik_element/picklist/language/en-GB/en-GB.plg_fabrik_element_picklist.sys.ini
+++ b/plugins/fabrik_element/picklist/language/en-GB/en-GB.plg_fabrik_element_picklist.sys.ini
@@ -1,13 +1,11 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_PICKLIST="Fabrik Element - Picklist"
 PLG_ELEMENT_PICKLIST_HELP_SERVER="http://fabrikar.com/forums/index.php?wiki/picklist-element/"
 PLG_ELEMENT_PICKLIST_DESCRIPTION="Renders dragable pick list"
-
 PLG_ELEMENT_FABRIK_OPTIONS="Options"
 PLG_ELEMENT_FABRIK_FIELD_TYPE_LABEL="Field type"
 PLG_ELEMENT_FABRIK_FIELD_TYPE_DESC="The database field type used when creating the element"

--- a/plugins/fabrik_element/radiobutton/language/en-GB/en-GB.plg_fabrik_element_radiobutton.ini
+++ b/plugins/fabrik_element/radiobutton/language/en-GB/en-GB.plg_fabrik_element_radiobutton.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005-2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_RADIO_ADD_OPTION_DESC="If yes then users can add in additional radio buttons to this element"

--- a/plugins/fabrik_element/radiobutton/language/en-GB/en-GB.plg_fabrik_element_radiobutton.sys.ini
+++ b/plugins/fabrik_element/radiobutton/language/en-GB/en-GB.plg_fabrik_element_radiobutton.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_RADIOBUTTON="Fabrik Element - Radio Button"

--- a/plugins/fabrik_element/rating/language/en-GB/en-GB.plg_fabrik_element_rating.ini
+++ b/plugins/fabrik_element/rating/language/en-GB/en-GB.plg_fabrik_element_rating.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005-2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_RATING_ONE="One"
@@ -18,5 +17,6 @@ PLG_ELEMENT_RATING_MODE_LABEL="Rating mode"
 PLG_ELEMENT_RATING_MODE_DESC="If set to 'user rating' then all users can vote on the record and an average score is show. If set to 'creator rating' then only the creator/editor of the record can change the rating and the changed rating is shown as opposed to the average."
 PLG_ELEMENT_RATING_FLOAT_LABEL="Decimals"
 PLG_ELEMENT_RATING_FLOAT_DESCRIPTION="If showing an average rating, this field specifies the number of decimals to show"
+
 ;front end
 PLG_ELEMENT_RATING_NO_RATING="No rating"

--- a/plugins/fabrik_element/rating/language/en-GB/en-GB.plg_fabrik_element_rating.sys.ini
+++ b/plugins/fabrik_element/rating/language/en-GB/en-GB.plg_fabrik_element_rating.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_RATING="Fabrik Element - Rating"

--- a/plugins/fabrik_element/slider/language/en-GB/en-GB.plg_fabrik_element_slider.sys.ini
+++ b/plugins/fabrik_element/slider/language/en-GB/en-GB.plg_fabrik_element_slider.sys.ini
@@ -1,10 +1,8 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_SLIDER="Fabrik Element - Slider"
 PLG_ELEMENT_SLIDER_HELP_SERVER="http://fabrikar.com/forums/index.php?wiki/rating-element/"
 PLG_ELEMENT_SLIDER_DESCRIPTION="Renders Mootools Slider"
-

--- a/plugins/fabrik_element/sugarid/sugarid.php
+++ b/plugins/fabrik_element/sugarid/sugarid.php
@@ -1,13 +1,15 @@
 <?php
 /**
+ * Plugin element to Sugar CRM id
+ *
  * @package     Joomla.Plugin
  * @subpackage  Fabrik.element.sugarid
- * @copyright   Copyright (C) 2005 Fabrik. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @copyright   Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+ * @license     GNU/GPL http://www.gnu.org/copyleft/gpl.html
  */
 
-// Check to ensure this file is included in Joomla!
-defined('_JEXEC') or die();
+// No direct access
+defined('_JEXEC') or die('Restricted access');
 
 require_once JPATH_SITE . '/components/com_fabrik/models/element.php';
 

--- a/plugins/fabrik_element/textarea/language/en-GB/en-GB.plg_fabrik_element_textarea.ini
+++ b/plugins/fabrik_element/textarea/language/en-GB/en-GB.plg_fabrik_element_textarea.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 ; Administration
@@ -38,6 +37,7 @@ PLG_ELEMENT_TEXTAREA_USE_WYSIWYG_EDITOR_DESC="Uses your site's WYSIWYG editor as
 PLG_ELEMENT_TEXTAREA_WIDTH_LABEL="Width"
 PLG_ELEMENT_TEXTAREA_WYSIWYG_EXTRA_BUTTONS_LABEL="Extended buttons"
 PLG_ELEMENT_TEXTAREA_WYSIWYG_EXTRA_BUTTONS_DESC="Show the Joomla exteneded editor buttons with the editor"
+
 ;front end
 PLG_ELEMENT_TEXTAREA_CHARACTERS_LEFT="Characters left"
 PLG_ELEMENT_TEXTAREA_WORDS_LEFT="Words left"

--- a/plugins/fabrik_element/textarea/language/en-GB/en-GB.plg_fabrik_element_textarea.sys.ini
+++ b/plugins/fabrik_element/textarea/language/en-GB/en-GB.plg_fabrik_element_textarea.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_TEXTAREA="Fabrik Element - Text Area"

--- a/plugins/fabrik_element/thumbs/language/en-GB/en-GB.plg_fabrik_element_thumbs.sys.ini
+++ b/plugins/fabrik_element/thumbs/language/en-GB/en-GB.plg_fabrik_element_thumbs.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_THUMBS="Fabrik Element - Thumbs"

--- a/plugins/fabrik_element/time/language/en-GB/en-GB.plg_fabrik_element_time.ini
+++ b/plugins/fabrik_element/time/language/en-GB/en-GB.plg_fabrik_element_time.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_TIME_DEFAULT_DESC="Default value must be in hh:mm:ss format, with 2 digits (zero padded) for each, and with : as the seperator, regardless of your optional display separator setting."

--- a/plugins/fabrik_element/time/language/en-GB/en-GB.plg_fabrik_element_time.sys.ini
+++ b/plugins/fabrik_element/time/language/en-GB/en-GB.plg_fabrik_element_time.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_TIME="Fabrik Element - Time"

--- a/plugins/fabrik_element/timer/language/en-GB/en-GB.plg_fabrik_element_timer.ini
+++ b/plugins/fabrik_element/timer/language/en-GB/en-GB.plg_fabrik_element_timer.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_TIMER_WIDTH_LABEL="Width"

--- a/plugins/fabrik_element/timer/language/en-GB/en-GB.plg_fabrik_element_timer.sys.ini
+++ b/plugins/fabrik_element/timer/language/en-GB/en-GB.plg_fabrik_element_timer.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_TIMER="Fabrik Element - Timer"

--- a/plugins/fabrik_element/timestamp/language/en-GB/en-GB.plg_fabrik_element_timestamp.ini
+++ b/plugins/fabrik_element/timestamp/language/en-GB/en-GB.plg_fabrik_element_timestamp.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_TIMESTAMP_FORMAT_DESC="Format the time based on PHP's date format - see here http://fphp.net/manual/en/function.date.php for all format options."

--- a/plugins/fabrik_element/timestamp/language/en-GB/en-GB.plg_fabrik_element_timestamp.sys.ini
+++ b/plugins/fabrik_element/timestamp/language/en-GB/en-GB.plg_fabrik_element_timestamp.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_TIMESTAMP="Fabrik Element - Timestamp"

--- a/plugins/fabrik_element/user/language/en-GB/en-GB.plg_fabrik_element_user.ini
+++ b/plugins/fabrik_element/user/language/en-GB/en-GB.plg_fabrik_element_user.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_USER_HIDDEN_LABEL="Hidden"

--- a/plugins/fabrik_element/user/language/en-GB/en-GB.plg_fabrik_element_user.sys.ini
+++ b/plugins/fabrik_element/user/language/en-GB/en-GB.plg_fabrik_element_user.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_USER="Fabrik Element - User"

--- a/plugins/fabrik_element/usergroup/language/en-GB/en-GB.plg_fabrik_element_usergroup.ini
+++ b/plugins/fabrik_element/usergroup/language/en-GB/en-GB.plg_fabrik_element_usergroup.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_USERGROUP_HIDDEN_LABEL="Hidden"

--- a/plugins/fabrik_element/usergroup/language/en-GB/en-GB.plg_fabrik_element_usergroup.sys.ini
+++ b/plugins/fabrik_element/usergroup/language/en-GB/en-GB.plg_fabrik_element_usergroup.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_USERGROUP="Fabrik Element - User Group"

--- a/plugins/fabrik_element/viewlevel/language/en-GB/en-GB.plg_fabrik_element_viewlevel.ini
+++ b/plugins/fabrik_element/viewlevel/language/en-GB/en-GB.plg_fabrik_element_viewlevel.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_USER_HIDDEN_LABEL="Hidden"
@@ -15,4 +14,3 @@ PLG_ELEMENT_USER_UPDATE_ON_COPY_LABEL="Update on copy"
 PLG_ELEMENT_USER_UPDATE_ON_COPY_DESC="If yes selected then the current users id will be stored when 'save as copy' button is used, so the element will take on the id of the user who copies the form."
 PLG_ELEMENT_USER_USE_SOCIAL_PROFILE_LABEL="Use Social Profile"
 PLG_ELEMENT_USER_USE_SOCIAL_PROFILE_DESC="If enabled, when creating a new record session data will be checked for fabrik.social.profile_id, and if present will be used as the user ID.  This is set by (for instance) the CB Plugin to the user ID of the profile being viewed."
-

--- a/plugins/fabrik_element/viewlevel/language/en-GB/en-GB.plg_fabrik_element_viewlevel.sys.ini
+++ b/plugins/fabrik_element/viewlevel/language/en-GB/en-GB.plg_fabrik_element_viewlevel.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_VIEWLEVE="Fabrik Element - View Level"

--- a/plugins/fabrik_element/yesno/language/en-GB/en-GB.plg_fabrik_element_yesno.ini
+++ b/plugins/fabrik_element/yesno/language/en-GB/en-GB.plg_fabrik_element_yesno.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_ELEMENT_YESNO_DEAFULT_LABEL="Default"

--- a/plugins/fabrik_element/yesno/language/en-GB/en-GB.plg_fabrik_element_yesno.sys.ini
+++ b/plugins/fabrik_element/yesno/language/en-GB/en-GB.plg_fabrik_element_yesno.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_YESNO="Fabrik Element - Yes / No"

--- a/plugins/fabrik_element/youtube/language/en-GB/en-GB.plg_fabrik_element_youtube.ini
+++ b/plugins/fabrik_element/youtube/language/en-GB/en-GB.plg_fabrik_element_youtube.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 INCLUDERELATEDVIDEOS="Include related"
@@ -24,4 +23,3 @@ DISPLAYLINKDESC="Only used if 'Display link' selected above. Specify the target 
 TEXTLINK="Text of the 'Watch Video' link"
 TARGETLINK="Target"
 TARGETLINKDESC="Lightbox will only work if you use Mootools 1.2 and mediabox (Tables > General Settings)"
-

--- a/plugins/fabrik_element/youtube/language/en-GB/en-GB.plg_fabrik_element_youtube.sys.ini
+++ b/plugins/fabrik_element/youtube/language/en-GB/en-GB.plg_fabrik_element_youtube.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_ELEMENT_YOUTUBE="Fabrik Element - YouTube video"

--- a/plugins/fabrik_form/alphauserpoints/language/en-GB/en-GB.plg_fabrik_form_alphauserpoints.ini
+++ b/plugins/fabrik_form/alphauserpoints/language/en-GB/en-GB.plg_fabrik_form_alphauserpoints.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_AUP_PLUGIN_DESC="Which plugin should we use to assign the user points"

--- a/plugins/fabrik_form/alphauserpoints/language/en-GB/en-GB.plg_fabrik_form_alphauserpoints.sys.ini
+++ b/plugins/fabrik_form/alphauserpoints/language/en-GB/en-GB.plg_fabrik_form_alphauserpoints.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_ALPHAUSERPOINTS="Fabrik Form - Alpha User Points"

--- a/plugins/fabrik_form/autofill/language/en-GB/en-GB.plg_fabrik_form_autofill.ini
+++ b/plugins/fabrik_form/autofill/language/en-GB/en-GB.plg_fabrik_form_autofill.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_AUTOFILL_CONFIRM_DESC="When the trigger element blurs or is clicked, do you want a confirmation box to appear asking the user if they want the fields to be autofilled"
@@ -10,10 +10,10 @@ PLG_FORM_AUTOFILL_CONNECTION_DESC="If you want the auto fill to update data from
 PLG_FORM_AUTOFILL_EDIT_ORIG_LABEL="Edit original record"
 PLG_FORM_AUTOFILL_EDIT_ORIG_DESC="If set to yes, then when the auto fill lookup is performed and a match found the form's row id is changed to that of the matched record, meaning that you will edit the original record"
 PLG_FORM_AUTOFILL_ELEMENT_MAP_LABEL="Map data"
-PLG_FORM_AUTOFILL_ELEMENT_MAP_DESC="An object represented as a json string.  Takes the 'from' field as the key and the 'to' field as that value - 
+PLG_FORM_AUTOFILL_ELEMENT_MAP_DESC="An object represented as a json string.  Takes the 'from' field as the key and the 'to' field as that value -
 
 e.g. {"_QQ_"acts___name"_QQ_":"_QQ_"events___title"_QQ_","_QQ_"acts___bio"_QQ_":"_QQ_"events___description"_QQ_"}
-Looks up artist, and puts the artist name in the events title, and the artist bio and puts it in the forms 'events___description' field.  
+Looks up artist, and puts the artist name in the events title, and the artist bio and puts it in the forms 'events___description' field.
 
 To map a single 'from' to multiple 'to' elements, use an array from the 'to' value, like ["_QQ_"table___field1"_QQ_","_QQ_"table___field2"_QQ_"]
 
@@ -35,7 +35,6 @@ PLG_FORM_AUTOFILL_CONFIRM_LABEL="Confirm"
 PLG_FORM_AUTOFILL_CONFIRM_DESC="Prompt for confirmation to run when observed element changes"
 
 ; front end
-
 PLG_FORM_AUTOFILL_DO_UPDATE="Do you want to search for an existing record that matches the data you have just entered?"
 PLG_FORM_AUTOFILL_SEARCHING="performing search"
 PLG_FORM_AUTOFILL_NORECORDS_FOUND="No matches found"

--- a/plugins/fabrik_form/autofill/language/en-GB/en-GB.plg_fabrik_form_autofill.sys.ini
+++ b/plugins/fabrik_form/autofill/language/en-GB/en-GB.plg_fabrik_form_autofill.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_AUTOFILL="Fabrik Form - Autofill"

--- a/plugins/fabrik_form/caneditgroup/language/en-GB/en-GB.plg_fabrik_form_caneditgroup.ini
+++ b/plugins/fabrik_form/caneditgroup/language/en-GB/en-GB.plg_fabrik_form_caneditgroup.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_LIMIT_LENGTH_LABEL="Limit length"

--- a/plugins/fabrik_form/clone/language/en-GB/en-GB.plg_fabrik_form_clone.ini
+++ b/plugins/fabrik_form/clone/language/en-GB/en-GB.plg_fabrik_form_clone.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_CLONE_TIMES_FIELD_LABEL="Clones"

--- a/plugins/fabrik_form/clone/language/en-GB/en-GB.plg_fabrik_form_clone.sys.ini
+++ b/plugins/fabrik_form/clone/language/en-GB/en-GB.plg_fabrik_form_clone.sys.ini
@@ -1,6 +1,6 @@
-C; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_CLONE="Fabrik Form - Clone"

--- a/plugins/fabrik_form/comment/language/en-GB/en-GB.plg_fabrik_form_comment.ini
+++ b/plugins/fabrik_form/comment/language/en-GB/en-GB.plg_fabrik_form_comment.ini
@@ -1,11 +1,9 @@
-; 
 ; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 ; Administration
-
 PLG_FORM_COMMENT_ALLOW_RATING_LABEL="Allow rating"
 PLG_FORM_COMMENT_ALLOW_RATING_DESC="Allow commnet ratings"
 PLG_FORM_COMMENT_ALLOW_ANANYMOUS_LABEL="Allow anonymous"

--- a/plugins/fabrik_form/comment/language/en-GB/en-GB.plg_fabrik_form_comment.sys.ini
+++ b/plugins/fabrik_form/comment/language/en-GB/en-GB.plg_fabrik_form_comment.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_COMMENT="Fabrik Form - Comment"

--- a/plugins/fabrik_form/confirmation/language/en-GB/en-GB.plg_fabrik_form_confirmation.ini
+++ b/plugins/fabrik_form/confirmation/language/en-GB/en-GB.plg_fabrik_form_confirmation.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_CONFIRMATION_RE_EDIT="Re-edit"

--- a/plugins/fabrik_form/confirmation/language/en-GB/en-GB.plg_fabrik_form_confirmation.sys.ini
+++ b/plugins/fabrik_form/confirmation/language/en-GB/en-GB.plg_fabrik_form_confirmation.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_CONFIRMATION="Fabrik Form - Confirmation"

--- a/plugins/fabrik_form/email/language/en-GB/en-GB.plg_fabrik_form_email.ini
+++ b/plugins/fabrik_form/email/language/en-GB/en-GB.plg_fabrik_form_email.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_EMAIL_GROUP_DESC="Optional: will also send to any user assigned to the selected groups. Shift click to select more than one group."
@@ -25,5 +25,6 @@ PLG_FABRIK_FORM_EMAIL_ATTACH_EVAL_LABEL="Attachments (eval)"
 PLG_FABRIK_FORM_EMAIL_ATTACH_EVAL_DESC="OPTIONAL - PHP code to add attachments.  Code just needs to return an array of full path name(s) to desired file(s).  Can use placeholders, and/or access form data in $this->data."
 PLG_FABRIK_FORM_EMAIL_MESSAGE_TEXT_LABEL="Message Text"
 PLG_FABRIK_FORM_EMAIL_MESSAGE_TEXT_DESC="OPTIONAL - text of message.  May use placeholders.  If specified in addition to an article template, the special placeholder {content} will incude the article template text.  If used in addition to the PHP/HTML template, the special placeholder {template} will include that text."
+
 ;Front end
 PLG_FORM_EMAIL_DID_NOT_SEND_EMAIL_INVALID_ADDRESS="Could not send email to %s, invalid address"

--- a/plugins/fabrik_form/email/language/en-GB/en-GB.plg_fabrik_form_email.sys.ini
+++ b/plugins/fabrik_form/email/language/en-GB/en-GB.plg_fabrik_form_email.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_EMAIL="Fabrik Form - Email"

--- a/plugins/fabrik_form/exif/language/en-GB/en-GB.plg_fabrik_form_exif.ini
+++ b/plugins/fabrik_form/exif/language/en-GB/en-GB.plg_fabrik_form_exif.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_EXIF_IMAGE_FIELD_LABEL="Image field"

--- a/plugins/fabrik_form/exif/language/en-GB/en-GB.plg_fabrik_form_exif.sys.ini
+++ b/plugins/fabrik_form/exif/language/en-GB/en-GB.plg_fabrik_form_exif.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_EXIF="Fabrik Form - Process Image EXIF Info"

--- a/plugins/fabrik_form/ftp/language/en-GB/en-GB.plg_fabrik_form_ftp.ini
+++ b/plugins/fabrik_form/ftp/language/en-GB/en-GB.plg_fabrik_form_ftp.ini
@@ -1,8 +1,7 @@
-# 
-# Joomla! Project
-# Copyright (C) 2005 - 2007 Open Source Matters. All rights reserved.
-# License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
-# Note : All ini files need to be saved as UTF-8 - No BOM
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
+; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_FTP_HOST_LABEL="Host"
 PLG_FORM_FTP_HOST_DESC="Hostname or IP of server to ftp to.  Do not prepend ftp://.  May use placeholders."

--- a/plugins/fabrik_form/ftp/language/en-GB/en-GB.plg_fabrik_form_ftp.sys.ini
+++ b/plugins/fabrik_form/ftp/language/en-GB/en-GB.plg_fabrik_form_ftp.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_FTP="Fabrik Form - FTP"

--- a/plugins/fabrik_form/juser/language/en-GB/en-GB.plg_fabrik_form_juser.ini
+++ b/plugins/fabrik_form/juser/language/en-GB/en-GB.plg_fabrik_form_juser.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_JUSER_AUTO_LOGIN_DESC="If Yes, will automatically log the new user in"

--- a/plugins/fabrik_form/juser/language/en-GB/en-GB.plg_fabrik_form_juser.sys.ini
+++ b/plugins/fabrik_form/juser/language/en-GB/en-GB.plg_fabrik_form_juser.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_JUSER="Fabrik Form - Create Joomla User"

--- a/plugins/fabrik_form/kunena/language/en-GB/en-GB.plg_fabrik_form_kunena.ini
+++ b/plugins/fabrik_form/kunena/language/en-GB/en-GB.plg_fabrik_form_kunena.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_KUNENA_CATEGORY_LABEL="Category"

--- a/plugins/fabrik_form/kunena/language/en-GB/en-GB.plg_fabrik_form_kunena.sys.ini
+++ b/plugins/fabrik_form/kunena/language/en-GB/en-GB.plg_fabrik_form_kunena.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_KUNENA="Fabrik Form - Kunena Forum"

--- a/plugins/fabrik_form/limit/language/en-GB/en-GB.plg_fabrik_form_limit.ini
+++ b/plugins/fabrik_form/limit/language/en-GB/en-GB.plg_fabrik_form_limit.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_LIMIT_ALLOW_ANONYMOUS_LABEL="Allow anonymous"

--- a/plugins/fabrik_form/limit/language/en-GB/en-GB.plg_fabrik_form_limit.sys.ini
+++ b/plugins/fabrik_form/limit/language/en-GB/en-GB.plg_fabrik_form_limit.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_LIMIT="Fabrik Form - Limit"

--- a/plugins/fabrik_form/logs/language/en-GB/en-GB.plg_fabrik_form_logs.ini
+++ b/plugins/fabrik_form/logs/language/en-GB/en-GB.plg_fabrik_form_logs.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_LOG_AORW_DESC="If Append is selected, the new log data will be added at the end of the file. If Overwrite is selected, the new log data will replace existing ones"
@@ -47,9 +47,6 @@ PLG_FORM_LOG_SEND_EMAIL_TO_DESC="Comma separated list of email addresses (no spa
 PLG_FORM_LOG_SEND_EMAIL_TO_LABEL="Email To"
 PLG_FORM_LOG_SEPARATOR_DESC="Separator to use between different data sets within the same file (for HTM or TXT only)"
 PLG_FORM_LOG_SEPARATOR_LABEL="Data set separator"
-
-
-
 PLG_FORM_LOG_REP_ADD="Add"
 PLG_FORM_LOG_REP_EDIT="Edit"
 PLG_FORM_LOG_COMPARE_DATA_CHANGE_ON="Changed on:"

--- a/plugins/fabrik_form/logs/language/en-GB/en-GB.plg_fabrik_form_logs.sys.ini
+++ b/plugins/fabrik_form/logs/language/en-GB/en-GB.plg_fabrik_form_logs.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_LOGS="Fabrik Form - Logs"

--- a/plugins/fabrik_form/mailchimp/language/en-GB/en-GB.plg_fabrik_form_mailchimp.ini
+++ b/plugins/fabrik_form/mailchimp/language/en-GB/en-GB.plg_fabrik_form_mailchimp.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2011 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_MAILCHIMP_API_KEY_LABEL="API key"
@@ -26,4 +26,4 @@ PLG_FORM_MAILCHIMP_EMAIL_TYPE_DESC="Determine if the user should receive text or
 PLG_FORM_MAILCHIMP_DOUBLE_OPTIN_LABEL="Double optin"
 PLG_FORM_MAILCHIMP_DOUBLE_OPTIN_DESC="If set to yes then an additional optin email will be sent to the user which they will need to reply to to subscribe to the list"
 PLG_FORM_MAILCHIMP_GROUP_OPTS_LABEL="Group options"
-PLG_FORM_MAILCHIMP_GROUP_OPTS_DESC="A json array of objects, which need to match up to this format: [{&quot;id&quot;:&quot;1&quot;,&quot;groups&quot;:&quot;{user_extended___plan_id}&quot;}] or [{&quot;name&quot;:&quot;Subscribers&quot;,&quot;groups&quot;:&quot;Silver&quot;}]" 
+PLG_FORM_MAILCHIMP_GROUP_OPTS_DESC="A json array of objects, which need to match up to this format: [{&quot;id&quot;:&quot;1&quot;,&quot;groups&quot;:&quot;{user_extended___plan_id}&quot;}] or [{&quot;name&quot;:&quot;Subscribers&quot;,&quot;groups&quot;:&quot;Silver&quot;}]"

--- a/plugins/fabrik_form/mailchimp/language/en-GB/en-GB.plg_fabrik_form_mailchimp.sys.ini
+++ b/plugins/fabrik_form/mailchimp/language/en-GB/en-GB.plg_fabrik_form_mailchimp.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_MAILCHIMP="Fabrik Form - Mailchimp"

--- a/plugins/fabrik_form/notification/language/en-GB/en-GB.plg_fabrik_form_notification.ini
+++ b/plugins/fabrik_form/notification/language/en-GB/en-GB.plg_fabrik_form_notification.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2011 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_NOTIFICATION_MODE_DESC="Can the user select to subscribe to the record, or does it happen when a certain set of conditions are met (trigger)"
@@ -14,10 +14,9 @@ PLG_FORM_NOTIFICATION_TRIGGER_VALUE_LABEL="Trigger value"
 PLG_FORM_NOTIFICATION_GROUP_DESC="Which groups should receive the notification"
 PLG_FORM_NOTIFICATION_GROUP_LABEL="Notify groups"
 PLG_CRON_NOTIFICATION_AJAX_SUBMIT_LABEL="Ajax subscribe"
-PLG_CRON_NOTIFICATION_AJAX_SUBMIT_DESC="Will toggling the 'notify me' checkbox update the notification via Ajax (i.e. without submitting the actual form)" 
+PLG_CRON_NOTIFICATION_AJAX_SUBMIT_DESC="Will toggling the 'notify me' checkbox update the notification via Ajax (i.e. without submitting the actual form)"
 
 ; front end
-
 PLG_CRON_NOTIFICATION_NOTIFY_ME="Notify me of updates"
 PLG_CRON_NOTIFICATION_SIGN_IN_TO_RECEIVE_NOTIFICATIONS="Sign in to receive notifications"
 PLG_CRON_NOTIFICATION_ADDED="Notification added"

--- a/plugins/fabrik_form/notification/language/en-GB/en-GB.plg_fabrik_form_notification.sys.ini
+++ b/plugins/fabrik_form/notification/language/en-GB/en-GB.plg_fabrik_form_notification.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_NOTIFICATION="Fabrik Form - Notification"

--- a/plugins/fabrik_form/paginate/language/en-GB/en-GB.plg_fabrik_form_paginate.ini
+++ b/plugins/fabrik_form/paginate/language/en-GB/en-GB.plg_fabrik_form_paginate.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_PAGINATE_AJAX_DESC="If set to yes, then the record will be loaded via Ajax, otherwise a page refresh will occur. If using form plug-in, such as comments, that behave differently for each URL then turn ajax off."

--- a/plugins/fabrik_form/paginate/language/en-GB/en-GB.plg_fabrik_form_paginate.sys.ini
+++ b/plugins/fabrik_form/paginate/language/en-GB/en-GB.plg_fabrik_form_paginate.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_PAGINATE="Fabrik Form - Paginate"

--- a/plugins/fabrik_form/paypal/language/en-GB/en-GB.plg_fabrik_form_paypal.ini
+++ b/plugins/fabrik_form/paypal/language/en-GB/en-GB.plg_fabrik_form_paypal.ini
@@ -1,8 +1,7 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
-
 
 PLG_FORM_PAYPAL_EMAILACCOUNT_LABEL="PayPal email account"
 PLG_FORM_PAYPAL_EMAILACCOUNT_DESC="The email address registered with PayPal that will accept the payment"

--- a/plugins/fabrik_form/paypal/language/en-GB/en-GB.plg_fabrik_form_paypal.sys.ini
+++ b/plugins/fabrik_form/paypal/language/en-GB/en-GB.plg_fabrik_form_paypal.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_PAYPAL="Fabrik Form - Paypal Processor"

--- a/plugins/fabrik_form/php/language/en-GB/en-GB.plg_fabrik_form_php.ini
+++ b/plugins/fabrik_form/php/language/en-GB/en-GB.plg_fabrik_form_php.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_PHP_PROCESS_CURL_LABEL="Process script"

--- a/plugins/fabrik_form/php/language/en-GB/en-GB.plg_fabrik_form_php.sys.ini
+++ b/plugins/fabrik_form/php/language/en-GB/en-GB.plg_fabrik_form_php.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_PHP="Fabrik Form - Run PHP"

--- a/plugins/fabrik_form/receipt/language/en-GB/en-GB.plg_fabrik_form_receipt.ini
+++ b/plugins/fabrik_form/receipt/language/en-GB/en-GB.plg_fabrik_form_receipt.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_RECEIPT_BUTTON_LABEL_DESC="If user's choice selected, then this set the text of the checkbox label. Leave blank to revert to default text 'Email me a copy'"

--- a/plugins/fabrik_form/receipt/language/en-GB/en-GB.plg_fabrik_form_receipt.sys.ini
+++ b/plugins/fabrik_form/receipt/language/en-GB/en-GB.plg_fabrik_form_receipt.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_RECEIPT="Fabrik Form - Receipt"

--- a/plugins/fabrik_form/redirect/language/en-GB/en-GB.plg_fabrik_form_redirect.ini
+++ b/plugins/fabrik_form/redirect/language/en-GB/en-GB.plg_fabrik_form_redirect.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_REDIRECT_JUMPPAGE_LABEL="Jump page"

--- a/plugins/fabrik_form/redirect/language/en-GB/en-GB.plg_fabrik_form_redirect.sys.ini
+++ b/plugins/fabrik_form/redirect/language/en-GB/en-GB.plg_fabrik_form_redirect.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_REDIRECT="Fabrik Form - Redirect"

--- a/plugins/fabrik_form/rest/language/de-DE/de-DE.plg_fabrik_form_rest.ini
+++ b/plugins/fabrik_form/rest/language/de-DE/de-DE.plg_fabrik_form_rest.ini
@@ -15,8 +15,8 @@ PLG_FORM_REST_USERNAME_DESC="Wenn ein REST Service verwendet wird der Authentifi
 PLG_FORM_REST_USERNAME_LABEL="Benutzername"
 PLG_FORM_REST_XML_PARENT_DESC="Der Übergeordneter XML Knoten Name - alle Anfrage Daten werden innerhalb dieses Tags eingeschlossen.<br /><br /> z.B. wenn 'ticket' eingestellt wird werden alle XML Daten mit &lt;ticket&gt;.....&lt;/ticket&gt; eingeschlossen.<br />Kann {platzhalter} verwenden"
 PLG_FORM_REST_XML_PARENT_LABEL="Übergeordneter Knoten Name"
-PLG_REST_PUT_ENDPOINT_DESC="Die URL für die put-Anforderung - wird zum Aktualisieren vorhandener Datensätze verwendet. Verwendet {platzhalter}. "
-PLG_REST_PUT_ENDPOINT_LABEL="Put URL"
+PLG_FORM_REST_PUT_ENDPOINT_DESC="Die URL für die put-Anforderung - wird zum Aktualisieren vorhandener Datensätze verwendet. Verwendet {platzhalter}. "
+PLG_FORM_REST_PUT_ENDPOINT_LABEL="Put URL"
 
 
 PLG_FORM_REST_PUT_INCLUDE_LIST_LABEL="Daten Zuordnung"

--- a/plugins/fabrik_form/rest/language/en-GB/en-GB.plg_fabrik_form_rest.sys.ini
+++ b/plugins/fabrik_form/rest/language/en-GB/en-GB.plg_fabrik_form_rest.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_REST="Fabrik Form - REST"

--- a/plugins/fabrik_form/salesforce/language/en-GB/en-GB.plg_fabrik_form_salesforce.ini
+++ b/plugins/fabrik_form/salesforce/language/en-GB/en-GB.plg_fabrik_form_salesforce.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_SALESFORCE_UPDATEOBJECT_LABEL="Update object"
@@ -18,15 +18,13 @@ PLG_FABRIK_FORM_SALESFORCE_CUSTOMID_DESC="You must have declared an external id 
 <li>Email</li>
 <li>Auto Number</li>
 </ol>
-<p>As a sforce administrator, you login to Salesforce.com and go to Setup > App Setup > Accounts > Fields. Then scroll down to Account Custom Fields and Relationships. Either Create a new field that you will be utilizing or edit a existing field which is a valid field type and make it an external field.</p> 
+<p>As a sforce administrator, you login to Salesforce.com and go to Setup > App Setup > Accounts > Fields. Then scroll down to Account Custom Fields and Relationships. Either Create a new field that you will be utilizing or edit a existing field which is a valid field type and make it an external field.</p>
 "
 PLG_FABRIK_FORM_SALESFORCE_ALLOWUPSERTS_LABEL="Allow upserts"
 PLG_FABRIK_FORM_SALESFORCE_ALLOWUPSERTS_DESC="If yes then salesforce records whose ids match the 'Custom id field' value will be updated (none matched records will be created). Otherwise a new salesforce record will always be created"
 
-
 ;Front end
-
-SALESFORCE_ERR="Salesforce.com Error:" 
+SALESFORCE_ERR="Salesforce.com Error:"
 SALESFORCE_NOCREATE="We were unable to create the Salesforce.com %s"
 SALESFORCE_CREATED="Salesforce.com %s created"
 SALESFORCE_UPDATED="Salesforce.com %s updated"

--- a/plugins/fabrik_form/salesforce/language/en-GB/en-GB.plg_fabrik_form_salesforce.sys.ini
+++ b/plugins/fabrik_form/salesforce/language/en-GB/en-GB.plg_fabrik_form_salesforce.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_SALESFORCE="Fabrik Form - Salesforce"

--- a/plugins/fabrik_form/sms/language/en-GB/en-GB.plg_fabrik_form_sms.ini
+++ b/plugins/fabrik_form/sms/language/en-GB/en-GB.plg_fabrik_form_sms.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_SMS_GATEWAY_LABEL="Gateway"

--- a/plugins/fabrik_form/sms/language/en-GB/en-GB.plg_fabrik_form_sms.sys.ini
+++ b/plugins/fabrik_form/sms/language/en-GB/en-GB.plg_fabrik_form_sms.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_SMS="Fabrik Form - SMS"

--- a/plugins/fabrik_form/subscriptions/language/en-GB/en-GB.plg_fabrik_form_subscriptions.ini
+++ b/plugins/fabrik_form/subscriptions/language/en-GB/en-GB.plg_fabrik_form_subscriptions.ini
@@ -1,11 +1,10 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_SUBSCRIPTIONS_EMAILACCOUNT_DESC="The email address registered with PayPal that will accept the payment, can use {placeholders}"
 PLG_FORM_SUBSCRIPTIONS_EMAILACCOUNT_LABEL="PayPal email account"
-
 PLG_FORM_SUBSCRIPTIONS_TEST_MODE_LABEL="Test mode"
 PLG_FORM_SUBSCRIPTIONS_TEST_MODE_DESC="If set to yes then the plug-in will post to the PayPal sand box. Use this for testing"
 PLG_FORM_SUBSCRIPTIONS_CONDITION_LABEL="Condition"

--- a/plugins/fabrik_form/subscriptions/language/en-GB/en-GB.plg_fabrik_form_subscriptions.sys.ini
+++ b/plugins/fabrik_form/subscriptions/language/en-GB/en-GB.plg_fabrik_form_subscriptions.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_SUBSCRIPTIONS="Fabrik Form - Paypal Subscriptions"

--- a/plugins/fabrik_form/twitter/language/en-GB/en-GB.plg_fabrik_form_twitter.ini
+++ b/plugins/fabrik_form/twitter/language/en-GB/en-GB.plg_fabrik_form_twitter.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_TWITTERMSGFIELD_LABEL="Message Element"
@@ -9,7 +9,6 @@ PLG_FORM_TWITTERSHOWSUCCESSMSG_LABEL="Show success message"
 PLG_FORM_TWITTERSHOWSUCCESSMSG_DESC="If we successfully send a tweet, show we add a notification message to the page informing user of success"
 PLG_FORM_TWITTERTMPLFIELD_LABEL="Tweet template"
 PLG_FORM_TWITTERTMPLFIELD_DESC="This is the text that is sent to twitter. Use {tablename___elementname} placeholders to insert the form's data into the tweet. Only used if the Message Element has an empty selection."
-
 PLG_FORM_TWITTER_BITLY_API_LOGIN="Bit.ly Login"
 PLG_FORM_TWITTER_BITLY_API_LOGIN_DESC="OPTIONAL - if both Bit.ly login and API key are specified, all URL's found in your tweet will be bitlyfied.  To obtain your Bit.ly API credentials, go to http://bit.ly/a/your_api_key"
 PLG_FORM_TWITTER_BITLY_API_KEY="Bit.ly API Key"
@@ -29,7 +28,6 @@ PLG_FORM_TWITTER_OAUTH_USER_DESC="This is the current user you have associated t
 PLG_FORM_TWITTER_OAUTH_USER_LABEL="User"
 PLG_FORM_TWITTER_SIGNIN_LABEL="Associate an account"
 PLG_FORM_TWITTER_SIGNIN_DESC="Press the 'sign in' button to associate your account with this form. When the form is submitted the twitter message will be posted to this account. Leave blank or clear to enable the user submitting the form to post to their own twitter account."
-
 
 ;front end
 PLG_FORM_TWITTER_ERR="There was an error updating twitter status."

--- a/plugins/fabrik_form/twitter/language/en-GB/en-GB.plg_fabrik_form_twitter.sys.ini
+++ b/plugins/fabrik_form/twitter/language/en-GB/en-GB.plg_fabrik_form_twitter.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_TWITTER="Fabrik Form - Twitter"

--- a/plugins/fabrik_form/upsert/language/en-GB/en-GB.plg_fabrik_form_upsert.ini
+++ b/plugins/fabrik_form/upsert/language/en-GB/en-GB.plg_fabrik_form_upsert.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2013 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FORM_UPSERT_CONNECTION_DESC="Fabrik connection"
@@ -16,4 +16,3 @@ PLG_FORM_UPSERT_ROWID_LABEL="Row value"
 PLG_FORM_UPSERT_TABLE_DESC="The Fabrik list to update/insert a record into"
 PLG_FORM_UPSERT_TABLE_LABEL="List"
 PLG_FORM_UPSERT_VALUE_LABEL="Value"
-

--- a/plugins/fabrik_form/upsert/language/en-GB/en-GB.plg_fabrik_form_upsert.sys.ini
+++ b/plugins/fabrik_form/upsert/language/en-GB/en-GB.plg_fabrik_form_upsert.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_UPSERT="Fabrik Form - Upsert"

--- a/plugins/fabrik_form/vbforum/language/en-GB/en-GB.plg_fabrik_form_vbforum.ini
+++ b/plugins/fabrik_form/vbforum/language/en-GB/en-GB.plg_fabrik_form_vbforum.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_VBFORUM_FORUM_LABEL="Forum"

--- a/plugins/fabrik_form/vbforum/language/en-GB/en-GB.plg_fabrik_form_vbforum.sys.ini
+++ b/plugins/fabrik_form/vbforum/language/en-GB/en-GB.plg_fabrik_form_vbforum.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_FORM_VBFORUM="Fabrik Form - vBulletin Forum"

--- a/plugins/fabrik_list/candeleterow/language/en-GB/en-GB.plg_fabrik_list_candeleterow.ini
+++ b/plugins/fabrik_list/candeleterow/language/en-GB/en-GB.plg_fabrik_list_candeleterow.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_LIST_CANDELETEROW_ACCESS_DESC="Which Joomla User 'Access level' will this plug-in be applied to"

--- a/plugins/fabrik_list/candeleterow/language/en-GB/en-GB.plg_fabrik_list_candeleterow.sys.ini
+++ b/plugins/fabrik_list/candeleterow/language/en-GB/en-GB.plg_fabrik_list_candeleterow.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_CANDELETEROW="Fabrik List - Can Delete Row"

--- a/plugins/fabrik_list/caneditrow/language/en-GB/en-GB.plg_fabrik_list_caneditrow.ini
+++ b/plugins/fabrik_list/caneditrow/language/en-GB/en-GB.plg_fabrik_list_caneditrow.ini
@@ -1,7 +1,6 @@
-; 
-; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_LIST_CANEDITROW_ACCESS_DESC="Which Joomla User 'Access level' will this plug-in be applied to"

--- a/plugins/fabrik_list/caneditrow/language/en-GB/en-GB.plg_fabrik_list_caneditrow.sys.ini
+++ b/plugins/fabrik_list/caneditrow/language/en-GB/en-GB.plg_fabrik_list_caneditrow.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_CANEDITROW="Fabrik List - Can Edit Row"

--- a/plugins/fabrik_list/copy/language/en-GB/en-GB.plg_fabrik_list_copy.ini
+++ b/plugins/fabrik_list/copy/language/en-GB/en-GB.plg_fabrik_list_copy.ini
@@ -1,6 +1,6 @@
-; Fabrik 3
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 ; Administrator

--- a/plugins/fabrik_list/copy/language/en-GB/en-GB.plg_fabrik_list_copy.sys.ini
+++ b/plugins/fabrik_list/copy/language/en-GB/en-GB.plg_fabrik_list_copy.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_COPY="Fabrik List - Copy"

--- a/plugins/fabrik_list/download/language/en-GB/en-GB.plg_fabrik_list_download.ini
+++ b/plugins/fabrik_list/download/language/en-GB/en-GB.plg_fabrik_list_download.ini
@@ -1,7 +1,6 @@
-;
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_DOWNLOAD_ACCESS_LABEL="Access"
@@ -19,5 +18,4 @@ PLG_FABRIK_LIST_DOWNLOAD_BUTTON_LABEL="Button label"
 PLG_FABRIK_LIST_IMAGE_LIBRARY_LABEL="Image library"
 
 ; FRONT END
-
 PLG_LIST_DOWNLOAD_DOWNLOAD="Download"

--- a/plugins/fabrik_list/download/language/en-GB/en-GB.plg_fabrik_list_download.sys.ini
+++ b/plugins/fabrik_list/download/language/en-GB/en-GB.plg_fabrik_list_download.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_DOWNLOAD="Fabrik List - Download"

--- a/plugins/fabrik_list/email/language/en-GB/en-GB.plg_fabrik_list_email.ini
+++ b/plugins/fabrik_list/email/language/en-GB/en-GB.plg_fabrik_list_email.ini
@@ -1,7 +1,6 @@
-;
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_EMAIL_ACCESS_LABEL="Access"
@@ -27,7 +26,7 @@ PLG_LIST_EMAIL_UPDATE_VALUE_LABEL="Update value"
 PLG_LIST_EMAIL_UPDATE_VALUE_DESC="The value to update the 'update' element to."
 PLG_LIST_EMAIL_BUTTON_LOCATION_LABEL="Button location"
 PLG_LIST_EMAIL_BUTTON_LOCATION_DESC="Where should the button to send the emails be placed?"
-PLG_LIST_EMAIL_TO_FIELD_HOW_DESC="If using 'Defined in Email To Field' for 'Get Email Address From', you can make this hidden, read only, or editable by the user.  If using any other address method, this setting is ignored." 
+PLG_LIST_EMAIL_TO_FIELD_HOW_DESC="If using 'Defined in Email To Field' for 'Get Email Address From', you can make this hidden, read only, or editable by the user.  If using any other address method, this setting is ignored."
 PLG_LIST_EMAIL_TO_FIELD_HOW_LABEL="Email Field Display"
 PLG_LIST_EMAIL_TO_FIELD_HOW_EDITABLE="Editable"
 PLG_LIST_EMAIL_TO_FIELD_HOW_READONLY="Read only"
@@ -62,9 +61,7 @@ PLG_LIST_EMAIL_TO_TYPE_FIELD="Defined in 'email to' field"
 PLG_LIST_EMAIL_TO_TYPE_TABLE="From table (multiselect)"
 PLG_LIST_EMAIL_TO_TYPE_TABLE_PICKLIST="From table (picklist)"
 
-
 ;FRONT END
-
 PLG_LIST_EMAIL_ERR_NO_TO_ELEMENT_SELECTED="No 'to' field selected"
 PLG_LIST_EMAIL_EMAIL="Email"
 PLG_LIST_EMAIL_ATTACHMENTS="Attachments"

--- a/plugins/fabrik_list/email/language/en-GB/en-GB.plg_fabrik_list_email.sys.ini
+++ b/plugins/fabrik_list/email/language/en-GB/en-GB.plg_fabrik_list_email.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_EMAIL="Fabrik List - Email"

--- a/plugins/fabrik_list/filter_view/language/en-GB/en-GB.plg_fabrik_list_filter_view.ini
+++ b/plugins/fabrik_list/filter_view/language/en-GB/en-GB.plg_fabrik_list_filter_view.ini
@@ -1,7 +1,6 @@
-;
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_LIST_FILTER_VIEW_LABEL_LABEL="Label"

--- a/plugins/fabrik_list/filter_view/language/en-GB/en-GB.plg_fabrik_list_filter_view.sys.ini
+++ b/plugins/fabrik_list/filter_view/language/en-GB/en-GB.plg_fabrik_list_filter_view.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_FILTER_VIEW="Fabrik List - Filter View"

--- a/plugins/fabrik_list/inlineedit/language/en-GB/en-GB.plg_fabrik_list_inlineedit.ini
+++ b/plugins/fabrik_list/inlineedit/language/en-GB/en-GB.plg_fabrik_list_inlineedit.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_LIST_INLINE_ACCESS_LABEL="Access"

--- a/plugins/fabrik_list/inlineedit/language/en-GB/en-GB.plg_fabrik_list_inlineedit.sys.ini
+++ b/plugins/fabrik_list/inlineedit/language/en-GB/en-GB.plg_fabrik_list_inlineedit.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_INLINEEDIT="Fabrik List - Inline Edit"

--- a/plugins/fabrik_list/js/language/en-GB/en-GB.plg_fabrik_list_js.ini
+++ b/plugins/fabrik_list/js/language/en-GB/en-GB.plg_fabrik_list_js.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_JS_ACCESS_LABEL="Access"
@@ -12,6 +11,4 @@ PLG_FABRIK_LIST_JS_FILE_LABEL="JavaScript file"
 PLG_FABRIK_LIST_JS_FILE_DESC="File to run, located in plugins/fabrik_list/js/scripts.  Set 'statusMsg' to return a status message which will override any static message configured below."
 PLG_FABRIK_LIST_JS_IMAGE_LABEL="Button image"
 PLG_FABRIK_LIST_JS_IMAGE_DESC="A button image name which will be looked for in the image overrides folders - see http://fabrikar.com/wiki/index.php/Image_overrides"
-
 PLG_FABRIK_LIST_JS_SUCCESS_MSG_LABEL="Success message"
-

--- a/plugins/fabrik_list/js/language/en-GB/en-GB.plg_fabrik_list_js.sys.ini
+++ b/plugins/fabrik_list/js/language/en-GB/en-GB.plg_fabrik_list_js.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_JS="Fabrik List - Run JS"

--- a/plugins/fabrik_list/listcsv/language/en-GB/en-GB.plg_fabrik_list_listcsv.sys.ini
+++ b/plugins/fabrik_list/listcsv/language/en-GB/en-GB.plg_fabrik_list_listcsv.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_LISTCSV="Fabrik List - CSV import"

--- a/plugins/fabrik_list/order/language/en-GB/en-GB.plg_fabrik_list_order.ini
+++ b/plugins/fabrik_list/order/language/en-GB/en-GB.plg_fabrik_list_order.ini
@@ -1,11 +1,10 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_LIST_ORDER_ELEMENT_DESC="The element to be used for ordering. The list needs to be ordered by this element for the ordering to be active. The element is expected to be an integer field.  Data in this field will be overwritten whenever you re-order the list."
 PLG_LIST_ORDER_ELEMENT_LABEL="Order element"
 PLG_LIST_ORDER_ELEMENT_AS_HANDLE_DESC="If set to yes then only the order element will be used as the handle to initiate the drag. If you are using a standard html table you MUST set this option to YES (otherwise links and buttons in the row will not be selectable)"
 PLG_LIST_ORDER_ELEMENT_AS_HANDLE_LABEL="Order element as handle"
-PLG_LIST_ORDER_ACCESS_LABEL="Access" 
+PLG_LIST_ORDER_ACCESS_LABEL="Access"

--- a/plugins/fabrik_list/order/language/en-GB/en-GB.plg_fabrik_list_order.sys.ini
+++ b/plugins/fabrik_list/order/language/en-GB/en-GB.plg_fabrik_list_order.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_ORDER="Fabrik List - Order"

--- a/plugins/fabrik_list/php/language/en-GB/en-GB.plg_fabrik_list_php.ini
+++ b/plugins/fabrik_list/php/language/en-GB/en-GB.plg_fabrik_list_php.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_PHP_ACCESS_LABEL="Access"
@@ -14,10 +13,8 @@ PLG_FABRIK_LIST_PHP_JS_CODE_DESC="Any JS code code entered here will be evaluate
 PLG_FABRIK_LIST_PHP_JS_CODE_LABEL="JS Code"
 PLG_FABRIK_LIST_PHP_IMAGE_LABEL="Button image"
 PLG_FABRIK_LIST_PHP_IMAGE_DESC="A button image name which will be looked for in the image overrides folders - see http://fabrikar.com/wiki/index.php/Image_overrides"
-
 PLG_FABRIK_LIST_PHP_SUCCESS_MSG_LABEL="Success message"
 
 ;FRONT END
-
 PLG_LIST_PHP_CODE_RUN="Code run"
 PLG_LIST_PHP_PHP="PHP"

--- a/plugins/fabrik_list/php/language/en-GB/en-GB.plg_fabrik_list_php.sys.ini
+++ b/plugins/fabrik_list/php/language/en-GB/en-GB.plg_fabrik_list_php.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_PHP="Fabrik List - Run PHP"

--- a/plugins/fabrik_list/php_events/language/en-GB/en-GB.plg_fabrik_list_php_events.sys.ini
+++ b/plugins/fabrik_list/php_events/language/en-GB/en-GB.plg_fabrik_list_php_events.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_PHP_EVENTS="Fabrik List - PHP Events"

--- a/plugins/fabrik_list/radius_search/language/en-GB/en-GB.plg_fabrik_list_radius_search.ini
+++ b/plugins/fabrik_list/radius_search/language/en-GB/en-GB.plg_fabrik_list_radius_search.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010- Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_LIST_RADIUS_SEARCH_COORDS_DESC="Search for records within a radius whose center is define by a user specified lat/lon"
@@ -29,7 +29,6 @@ PLG_LIST_RADIUS_SEARCH_START_FILTER_DISTANCE_DESC="If set to a number then the l
 PLG_LIST_RADIUS_SEARCH_START_FILTER_DISTANCE_LABEL="Prefilter distance"
 
 ; Front end
-
 PLG_VIEW_RADIUS_ACTIVE="Active"
 PLG_VIEW_RADIUS_COORDINATES="Coordinates"
 PLG_VIEW_RADIUS_DISTANCE="Radius Distance"

--- a/plugins/fabrik_list/radius_search/language/en-GB/en-GB.plg_fabrik_list_radius_search.sys.ini
+++ b/plugins/fabrik_list/radius_search/language/en-GB/en-GB.plg_fabrik_list_radius_search.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_RADIUS_SEARCH="Fabrik List - Radius Search"

--- a/plugins/fabrik_list/update_col/language/en-GB/en-GB.plg_fabrik_list_update_col.ini
+++ b/plugins/fabrik_list/update_col/language/en-GB/en-GB.plg_fabrik_list_update_col.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2011- Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_LIST_UPDATE_COL_ACCESS_LABEL="Access"
@@ -36,7 +36,6 @@ PLG_LIST_UPDATE_COL_VIEW_SETTINGS_LABEL="Update"
 PLG_LIST_UPDATE_COL_EVAL_DESC="Evaluate the 'Email message' as PHP. If selected then the 'Email message' should be valid PHP, and 'return' a string"
 
 ;FRONT END
-
 PLG_LIST_UPDATE_COL_UPDATE_COL="Update col"
 PLG_LIST_UPDATE_COL_UPDATE="Update";
 PLG_LIST_UPDATE_COL_UPDATE_MESSAGE="%d rows updated, %d emails sent"

--- a/plugins/fabrik_list/update_col/language/en-GB/en-GB.plg_fabrik_list_update_col.sys.ini
+++ b/plugins/fabrik_list/update_col/language/en-GB/en-GB.plg_fabrik_list_update_col.sys.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_UPDATE_COL="Fabrik List - Update Column"

--- a/plugins/fabrik_list/webservice/language/en-GB/en-GB.plg_fabrik_list_webservice.ini
+++ b/plugins/fabrik_list/webservice/language/en-GB/en-GB.plg_fabrik_list_webservice.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_WEBSERVICE_ACCESS_LABEL="Access"
@@ -36,5 +35,4 @@ PLG_FABRIK_LIST_WEBSERVICE_URL_LABEL="End point"
 PLG_FABRIK_LIST_WEBSERVICE_VALUE_LABEL="Value"
 
 ;FRONT END
-
 PLG_LIST_WEBSERVICE_CODE_RUN="Webservice run"

--- a/plugins/fabrik_list/webservice/language/en-GB/en-GB.plg_fabrik_list_webservice.sys.ini
+++ b/plugins/fabrik_list/webservice/language/en-GB/en-GB.plg_fabrik_list_webservice.sys.ini
@@ -1,6 +1,6 @@
-;
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_LIST_WEBSERVICE="Fabrik List - Webservice"

--- a/plugins/fabrik_validationrule/akismet/language/en-GB/en-GB.plg_fabrik_validationrule_akismet.sys.ini
+++ b/plugins/fabrik_validationrule/akismet/language/en-GB/en-GB.plg_fabrik_validationrule_akismet.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_AKISMET="Fabrik Validation - Akismet"

--- a/plugins/fabrik_validationrule/areuniquevalues/language/en-GB/en-GB.plg_fabrik_validationrule_areuniquevalues.sys.ini
+++ b/plugins/fabrik_validationrule/areuniquevalues/language/en-GB/en-GB.plg_fabrik_validationrule_areuniquevalues.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_AREUNIQUEVALUES="Fabrik Validation - are unique values"

--- a/plugins/fabrik_validationrule/emailexists/language/en-GB/en-GB.plg_fabrik_validationrule_emailexists.ini
+++ b/plugins/fabrik_validationrule/emailexists/language/en-GB/en-GB.plg_fabrik_validationrule_emailexists.ini
@@ -1,7 +1,6 @@
-; 
-; Joomla! Project
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_VALIDATIONRULE_EMAILEXISTS_ERROR_LABEL="Error message"
@@ -14,7 +13,6 @@ PLG_VALIDATIONRULE_EMAILEXISTS_CONDTION_LABEL="Condition"
 PLG_VALIDATIONRULE_EMAILEXISTS_CONDTION_DESC="Leave blank to always run.Otherwise enter a PHP expression that will return false if you want to stop the validation from occurring"
 PLG_VALIDATIONRULE_EMAILEXISTS_USER_FIELD_LABEL="User Element"
 PLG_VALIDATIONRULE_EMAILEXISTS_USER_FIELD_DESC="OPTIONAL (but strongly recommended)- if specified, this should be a user element on your form, which this plugin will then use when editing existing data, to determine if an existing row in the J! users table "belongs" to this user.  If not specified, plugin will use logged on userid, so will fail if (say) an admin is editing someone else's row"
-
 PLG_FABRIK_OPTIONS="Options"
 PLG_FABRIK_VALIDATION_ICON_DESC="Bootstrap icon name (or image name for J2.5), leave off 'icon-' prefix. Shown in the form, next to validation explaination text"
 PLG_FABRIK_VALIDATION_ICON_LABEL="Icon"

--- a/plugins/fabrik_validationrule/emailexists/language/en-GB/en-GB.plg_fabrik_validationrule_emailexists.sys.ini
+++ b/plugins/fabrik_validationrule/emailexists/language/en-GB/en-GB.plg_fabrik_validationrule_emailexists.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_EMAILEXISTS="Fabrik Validation - email exists in Joomla"

--- a/plugins/fabrik_validationrule/isalphanumeric/language/en-GB/en-GB.plg_fabrik_validationrule_isalphanumeric.sys.ini
+++ b/plugins/fabrik_validationrule/isalphanumeric/language/en-GB/en-GB.plg_fabrik_validationrule_isalphanumeric.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_ISALPHANUMERIC="Fabrik Validation - is alphanumeric"

--- a/plugins/fabrik_validationrule/isemail/language/en-GB/en-GB.plg_fabrik_validationrule_isemail.sys.ini
+++ b/plugins/fabrik_validationrule/isemail/language/en-GB/en-GB.plg_fabrik_validationrule_isemail.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_ISEMAIL="Fabrik Validation - is email"

--- a/plugins/fabrik_validationrule/isgreaterorlessthan/language/en-GB/en-GB.plg_fabrik_validationrule_isgreaterorlessthan.sys.ini
+++ b/plugins/fabrik_validationrule/isgreaterorlessthan/language/en-GB/en-GB.plg_fabrik_validationrule_isgreaterorlessthan.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_ISGREATERORLESSTHAN="Fabrik Validation - greater than or less than"

--- a/plugins/fabrik_validationrule/isnot/language/en-GB/en-GB.plg_fabrik_validationrule_isnot.ini
+++ b/plugins/fabrik_validationrule/isnot/language/en-GB/en-GB.plg_fabrik_validationrule_isnot.ini
@@ -1,7 +1,7 @@
 ; 
 ; Joomla! Project
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_VALIDATIONRULE_ISNOT_ERROR_LABEL="Error message"
@@ -10,7 +10,6 @@ PLG_VALIDATIONRULE_ISNOT_CONDITION_LABEL="Condition"
 PLG_VALIDATIONRULE_ISNOT_CONDITION_DESC="PHP code that returns true if the validation is to be run"
 PLG_VALIDATIONRULE_ISNOT_VALIDATION_LABEL="Is Not"
 PLG_VALIDATIONRULE_ISNOT_VALIDATION_DESC="Value this element cannot have (i.e. fails validation if matches), useful for matching against 'Please Select...' value of a dropdown. If you want to match against more than one value please separate the values with a \| e.g. a\|b\|c"
-
 PLG_FABRIK_OPTIONS="Options"
 PLG_FABRIK_VALIDATION_ICON_DESC="Bootstrap icon name (or image name for J2.5), leave off 'icon-' prefix. Shown in the form, next to validation explaination text"
 PLG_FABRIK_VALIDATION_ICON_LABEL="Icon"

--- a/plugins/fabrik_validationrule/isnot/language/en-GB/en-GB.plg_fabrik_validationrule_isnot.sys.ini
+++ b/plugins/fabrik_validationrule/isnot/language/en-GB/en-GB.plg_fabrik_validationrule_isnot.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_ISNOT="Fabrik Validation - is not"

--- a/plugins/fabrik_validationrule/isnumeric/language/en-GB/en-GB.plg_fabrik_validationrule_isnumeric.sys.ini
+++ b/plugins/fabrik_validationrule/isnumeric/language/en-GB/en-GB.plg_fabrik_validationrule_isnumeric.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_ISNUMERIC="Fabrik Validation - is numeric"

--- a/plugins/fabrik_validationrule/isuniquevalue/language/en-GB/en-GB.plg_fabrik_validationrule_isuniquevalue.sys.ini
+++ b/plugins/fabrik_validationrule/isuniquevalue/language/en-GB/en-GB.plg_fabrik_validationrule_isuniquevalue.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_ISUNIQUEVALUE="Fabrik Validation - is unique"

--- a/plugins/fabrik_validationrule/notempty/language/en-GB/en-GB.plg_fabrik_validationrule_notempty.sys.ini
+++ b/plugins/fabrik_validationrule/notempty/language/en-GB/en-GB.plg_fabrik_validationrule_notempty.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_NOTEMPTY="Fabrik Validation - not empty"

--- a/plugins/fabrik_validationrule/openprovider/language/en-GB/en-GB.plg_fabrik_validationrule_openprovider.ini
+++ b/plugins/fabrik_validationrule/openprovider/language/en-GB/en-GB.plg_fabrik_validationrule_openprovider.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_VALIDATION_OPENPROVIDER_USERNAME_LABEL="Username"

--- a/plugins/fabrik_validationrule/openprovider/language/en-GB/en-GB.plg_fabrik_validationrule_openprovider.sys.ini
+++ b/plugins/fabrik_validationrule/openprovider/language/en-GB/en-GB.plg_fabrik_validationrule_openprovider.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_OPENPROVIDER="Fabrik Validation - Open provider"

--- a/plugins/fabrik_validationrule/php/language/en-GB/en-GB.plg_fabrik_validationrule_php.ini
+++ b/plugins/fabrik_validationrule/php/language/en-GB/en-GB.plg_fabrik_validationrule_php.ini
@@ -1,7 +1,6 @@
-; 
-; Joomla! Project
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_VALIDATIONRULE_PHP_ERROR_LABEL="Error message"
@@ -14,7 +13,6 @@ PLG_VALIDATIONRULE_PHP_MATCH_OR_REPLACE_LABEL="Match or Replace"
 PLG_VALIDATIONRULE_PHP_MATCH_OR_REPLACE_DESC="If Match is selected, your PHP script should return 'true' (validated) or 'false' (failed).  If Replace is selected, your PHP script should return the replacement string."
 PLG_VALIDATIONRULE_PHP_REPLACE="Replace"
 PLG_VALIDATIONRULE_PHP_MATCH="Match"
-
 PLG_FABRIK_OPTIONS="Options"
 PLG_FABRIK_VALIDATION_ICON_DESC="Bootstrap icon name (or image name for J2.5), leave off 'icon-' prefix. Shown in the form, next to validation explaination text"
 PLG_FABRIK_VALIDATION_ICON_LABEL="Icon"

--- a/plugins/fabrik_validationrule/php/language/en-GB/en-GB.plg_fabrik_validationrule_php.sys.ini
+++ b/plugins/fabrik_validationrule/php/language/en-GB/en-GB.plg_fabrik_validationrule_php.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_PHP="Fabrik Validation - PHP"

--- a/plugins/fabrik_validationrule/regex/language/en-GB/en-GB.plg_fabrik_validationrule_regex.ini
+++ b/plugins/fabrik_validationrule/regex/language/en-GB/en-GB.plg_fabrik_validationrule_regex.ini
@@ -1,7 +1,6 @@
-; 
-; Joomla! Project
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_VALIDATIONRULE_REGEX_ERROR_LABEL="Error message"
@@ -16,7 +15,6 @@ PLG_VALIDATIONRULE_REGEX_REPLACE="Replace"
 PLG_VALIDATIONRULE_REGEX_MATCH="Match"
 PLG_VALIDATIONRULE_REGEX_REPLACE_STRING_LABEL="Replace string"
 PLG_VALIDATIONRULE_REGEX_REPLACE_STRING_DESC="If 'replace' selected above, then the matched data will be replaced with this fields text, and the form submitted (unless of course another validation fails in the form)."
-
 PLG_FABRIK_OPTIONS="Options"
 PLG_FABRIK_VALIDATION_ICON_DESC="Bootstrap icon name (or image name for J2.5), leave off 'icon-' prefix. Shown in the form, next to validation explaination text"
 PLG_FABRIK_VALIDATION_ICON_LABEL="Icon"

--- a/plugins/fabrik_validationrule/regex/language/en-GB/en-GB.plg_fabrik_validationrule_regex.sys.ini
+++ b/plugins/fabrik_validationrule/regex/language/en-GB/en-GB.plg_fabrik_validationrule_regex.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_REGEX="Fabrik Validation - Regex"

--- a/plugins/fabrik_validationrule/specialchars/language/en-GB/en-GB.plg_fabrik_validationrule_specialchars.ini
+++ b/plugins/fabrik_validationrule/specialchars/language/en-GB/en-GB.plg_fabrik_validationrule_specialchars.ini
@@ -1,7 +1,6 @@
-; 
-; Joomla! Project
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_VALIDATIONRULE_SPECIALCHARS_ERROR_LABEL="Error message"

--- a/plugins/fabrik_validationrule/specialchars/language/en-GB/en-GB.plg_fabrik_validationrule_specialchars.sys.ini
+++ b/plugins/fabrik_validationrule/specialchars/language/en-GB/en-GB.plg_fabrik_validationrule_specialchars.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_SPECIALCHARS="Fabrik Validation - Special Characters"

--- a/plugins/fabrik_validationrule/userexists/language/en-GB/en-GB.plg_fabrik_validationrule_userexists.ini
+++ b/plugins/fabrik_validationrule/userexists/language/en-GB/en-GB.plg_fabrik_validationrule_userexists.ini
@@ -1,7 +1,6 @@
-; 
-; Joomla! Project
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_VALIDATIONRULE_USEREXISTS_LABEL="Please enter a unique user name"

--- a/plugins/fabrik_validationrule/userexists/language/en-GB/en-GB.plg_fabrik_validationrule_userexists.sys.ini
+++ b/plugins/fabrik_validationrule/userexists/language/en-GB/en-GB.plg_fabrik_validationrule_userexists.sys.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
 ; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VALIDATIONRULE_USEREXISTS="Fabrik Validation - User Exists"

--- a/plugins/fabrik_visualization/approvals/language/en-GB/en-GB.plg_fabrik_visualization_approvals.ini
+++ b/plugins/fabrik_visualization/approvals/language/en-GB/en-GB.plg_fabrik_visualization_approvals.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2011 Pollen 8 Design Ltd
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_VIZ_APPROVALS_CONNECTION_LABEL="Connection"

--- a/plugins/fabrik_visualization/approvals/language/en-GB/en-GB.plg_fabrik_visualization_approvals.sys.ini
+++ b/plugins/fabrik_visualization/approvals/language/en-GB/en-GB.plg_fabrik_visualization_approvals.sys.ini
@@ -1,7 +1,6 @@
-;
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VISUALIZATION_APPROVALS="Fabrik Visualization - Approvals"

--- a/plugins/fabrik_visualization/calendar/language/en-GB/en-GB.plg_fabrik_visualization_calendar.ini
+++ b/plugins/fabrik_visualization/calendar/language/en-GB/en-GB.plg_fabrik_visualization_calendar.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 ; Administration

--- a/plugins/fabrik_visualization/calendar/language/en-GB/en-GB.plg_fabrik_visualization_calendar.sys.ini
+++ b/plugins/fabrik_visualization/calendar/language/en-GB/en-GB.plg_fabrik_visualization_calendar.sys.ini
@@ -1,7 +1,6 @@
-;
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VISUALIZATION_CALENDAR="Fabrik Visualization - calendar"

--- a/plugins/fabrik_visualization/chart/language/en-GB/en-GB.plg_fabrik_visualization_chart.ini
+++ b/plugins/fabrik_visualization/chart/language/en-GB/en-GB.plg_fabrik_visualization_chart.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 ; Administration
@@ -19,7 +18,6 @@ PLG_VISUALIZATION_CHART_AXIS_MEAUSREMENT_UNIT_LABEL="Axis measurement unit"
 PLG_VISUALIZATION_CHART_AXIS_MEAUSREMENT_UNIT_DESC="E.g. '%', 'cm' etc"
 PLG_VISUALIZATION_CHART_CUSTOM_DESC="Custom query string code to add the the chart, e.g. use 'chbh=a' to get bar chart columns to auto scale to fill the chart width"
 PLG_VISUALIZATION_CHART_CUSTOM_LABEL="Custom qs"
-
 PLG_VISUALIZATION_CHART_WHERE_LABEL="Where"
 PLG_VISUALIZATION_CHART_WHERE_DESC="Add a where SQL statement to filter the table results. E.g. name = 'rob'"
 PLG_VISUALIZATION_CHART_TEMPLATE_LABEL="Template"

--- a/plugins/fabrik_visualization/chart/language/en-GB/en-GB.plg_fabrik_visualization_chart.sys.ini
+++ b/plugins/fabrik_visualization/chart/language/en-GB/en-GB.plg_fabrik_visualization_chart.sys.ini
@@ -1,7 +1,6 @@
-;
-; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VISUALIZATION_CHART="Fabrik Visualization - Chart"

--- a/plugins/fabrik_visualization/coverflow/language/en-GB/en-GB.plg_fabrik_visualization_coverflow.ini
+++ b/plugins/fabrik_visualization/coverflow/language/en-GB/en-GB.plg_fabrik_visualization_coverflow.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_VISUALIZATION_COVERFLOW_CONNECTION_LABEL="Connection"

--- a/plugins/fabrik_visualization/coverflow/language/en-GB/en-GB.plg_fabrik_visualization_coverflow.sys.ini
+++ b/plugins/fabrik_visualization/coverflow/language/en-GB/en-GB.plg_fabrik_visualization_coverflow.sys.ini
@@ -1,7 +1,6 @@
-;
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VISUALIZATION_COVERFLOW="Fabrik Visualization - Coverflow"

--- a/plugins/fabrik_visualization/fusion_gantt_chart/language/en-GB/en-GB.plg_fabrik_visualization_fusion_gantt_chart.ini
+++ b/plugins/fabrik_visualization/fusion_gantt_chart/language/en-GB/en-GB.plg_fabrik_visualization_fusion_gantt_chart.ini
@@ -1,10 +1,9 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 ; Administration
-
 PLG_VISUALIZATION_GANTT_TABLE_LABEL="List"
 PLG_VISUALIZATION_GANNT_PROCESS_LABEL="Process"
 PLG_VISUALIZATION_GANNT_PROCESS_DESC="All tasks with the same process element value will be listed on the same line in the gantt chart"

--- a/plugins/fabrik_visualization/fusion_gantt_chart/language/en-GB/en-GB.plg_fabrik_visualization_fusion_gantt_chart.sys.ini
+++ b/plugins/fabrik_visualization/fusion_gantt_chart/language/en-GB/en-GB.plg_fabrik_visualization_fusion_gantt_chart.sys.ini
@@ -1,7 +1,6 @@
-;
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VISUALIZATION_FUSION_GANTT_CHART="Fabrik Visualization - Fusion Gantt Chart"

--- a/plugins/fabrik_visualization/fusionchart/language/en-GB/en-GB.plg_fabrik_visualization_fusionchart.ini
+++ b/plugins/fabrik_visualization/fusionchart/language/en-GB/en-GB.plg_fabrik_visualization_fusionchart.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_VISUALIZATION_FUSIONCHART_ANIMATION_DESC="Whether the animation is to be played or whether the entire chart would be rendered at one go. <strong>FusionCharts Attribute: animation</strong>"

--- a/plugins/fabrik_visualization/fusionchart/language/en-GB/en-GB.plg_fabrik_visualization_fusionchart.sys.ini
+++ b/plugins/fabrik_visualization/fusionchart/language/en-GB/en-GB.plg_fabrik_visualization_fusionchart.sys.ini
@@ -1,7 +1,6 @@
-;
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VISUALIZATION_FUSIONCHARTS="Fabrik Visualization - FusionChart"

--- a/plugins/fabrik_visualization/googlemap/language/en-GB/en-GB.plg_fabrik_visualization_googlemap.ini
+++ b/plugins/fabrik_visualization/googlemap/language/en-GB/en-GB.plg_fabrik_visualization_googlemap.ini
@@ -1,9 +1,7 @@
-; 
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
-
 
 PLG_VISUALIZATION_GOOGLEMAP_ADVANCED_HEADING="Advanced"
 PLG_VISUALIZATION_GOOGLEMAP_AJAX_REFRESH_LABEL="Ajax refresh"

--- a/plugins/fabrik_visualization/googlemap/language/en-GB/en-GB.plg_fabrik_visualization_googlemap.sys.ini
+++ b/plugins/fabrik_visualization/googlemap/language/en-GB/en-GB.plg_fabrik_visualization_googlemap.sys.ini
@@ -1,7 +1,6 @@
-;
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VISUALIZATION_GOOGLEMAP="Fabrik Visualization - Google Map"

--- a/plugins/fabrik_visualization/media/language/en-GB/en-GB.plg_fabrik_visualization_media.ini
+++ b/plugins/fabrik_visualization/media/language/en-GB/en-GB.plg_fabrik_visualization_media.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_VISUALIZATION_MEDIA_TABLE_LABEL="List"

--- a/plugins/fabrik_visualization/media/language/en-GB/en-GB.plg_fabrik_visualization_media.sys.ini
+++ b/plugins/fabrik_visualization/media/language/en-GB/en-GB.plg_fabrik_visualization_media.sys.ini
@@ -1,7 +1,6 @@
-;
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VISUALIZATION_MEDIA="Fabrik Visualization - Media"

--- a/plugins/fabrik_visualization/nvd3_chart/forms/fields.xml
+++ b/plugins/fabrik_visualization/nvd3_chart/forms/fields.xml
@@ -41,8 +41,8 @@
 				show="1" hide="0" toggle="data-labels-in-fieldnames"
 				alt="data-labels-in-data"
 				default="0"
-				label="PLG_FBRIK_VIZ_NV3D_DATA_MODE_LABEL"
-				description="PLG_FBRIK_VIZ_NV3D_DATA_MODE_DESC">
+				label="PLG_FABRIK_VIZ_NV3D_DATA_MODE_LABEL"
+				description="PLG_FABRIK_VIZ_NV3D_DATA_MODE_DESC">
 					<option value="0">PLG_FABRIK_VIZ_NV3D_LABELS_IN_DATA</option>
 					<option value="1">PLG_FABRIK_VIZ_NV3D_LABELS_IN_FIELDNAMES</option>	
 			</field>

--- a/plugins/fabrik_visualization/nvd3_chart/language/en-GB/en-GB.plg_fabrik_visualization_nvd3_chart.ini
+++ b/plugins/fabrik_visualization/nvd3_chart/language/en-GB/en-GB.plg_fabrik_visualization_nvd3_chart.ini
@@ -1,8 +1,7 @@
-; 
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
-
 
 PLG_FABRIK_VIZ_CHART_LABEL="Chart type"
 PLG_FABRIK_VIZ_NVD3_CONNECTON_LABEL="Connection"
@@ -30,9 +29,8 @@ PLG_FABRIK_VIZ_NV3D_CONTROLS_DESC="Show the chart controls, toggles between stac
 PLG_FABRIK_VIZ_NV3D_CONTROLS_LABEL="Controls"
 PLG_FABRIK_VIZ_NV3D_ROTATE_LABELS_DESC="Angle 0 - 360 to rotate the labels by"
 PLG_FABRIK_VIZ_NV3D_ROTATE_LABELS_LABEL="Rotate labels"
-
-PLG_FBRIK_VIZ_NV3D_DATA_MODE_DESC="The chart can take data in two basic formats:<br /><strong>Labels in data: </strong> The list has two columns one containing the labels and one containing the values<br /><strong>Labels in field names:</strong> The chart columns are built from the table's columns. Define which columns are used in the 'Chart columns' textarea"
-PLG_FBRIK_VIZ_NV3D_DATA_MODE_LABEL="Data mode"
+PLG_FABRIK_VIZ_NV3D_DATA_MODE_DESC="The chart can take data in two basic formats:<br /><strong>Labels in data: </strong> The list has two columns one containing the labels and one containing the values<br /><strong>Labels in field names:</strong> The chart columns are built from the table's columns. Define which columns are used in the 'Chart columns' textarea"
+PLG_FABRIK_VIZ_NV3D_DATA_MODE_LABEL="Data mode"
 PLG_FABRIK_VIZ_NV3D_LABELS_IN_DATA="Labels in data"
 PLG_FABRIK_VIZ_NV3D_LABELS_IN_FIELDNAMES="Labels in field names"
 PLG_FABRIK_VIZ_NV3D_LABEL_COLUMNS_DESC="Enter a comma separated list of the list columns containing the chart data, e.g:<br />age_5, age_5_10<br /><br />To make custom label for these columns add AS statments e.g:<br />age_5 AS '0 - 5', age_5_10 AS '5 - 10'"

--- a/plugins/fabrik_visualization/nvd3_chart/language/en-GB/en-GB.plg_fabrik_visualization_nvd3_chart_sys.ini
+++ b/plugins/fabrik_visualization/nvd3_chart/language/en-GB/en-GB.plg_fabrik_visualization_nvd3_chart_sys.ini
@@ -1,7 +1,6 @@
-;
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VISUALIZATION_NVD3_CHART="Fabrik Visualization - nvd3 Chart"

--- a/plugins/fabrik_visualization/slideshow/language/en-GB/en-GB.plg_fabrik_visualization_slideshow.ini
+++ b/plugins/fabrik_visualization/slideshow/language/en-GB/en-GB.plg_fabrik_visualization_slideshow.ini
@@ -1,7 +1,6 @@
-; 
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_VISUALIZATION_SLIDESHOW_CAPTION_DESC="Optional.  Element on the Image Table which stores the caption for the image."

--- a/plugins/fabrik_visualization/slideshow/language/en-GB/en-GB.plg_fabrik_visualization_slideshow.sys.ini
+++ b/plugins/fabrik_visualization/slideshow/language/en-GB/en-GB.plg_fabrik_visualization_slideshow.sys.ini
@@ -1,7 +1,6 @@
-;
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VISUALIZATION_SLIDESHOW="Fabrik Visualization - Slideshow"

--- a/plugins/fabrik_visualization/timeline/language/en-GB/en-GB.plg_fabrik_visualization_timeline.ini
+++ b/plugins/fabrik_visualization/timeline/language/en-GB/en-GB.plg_fabrik_visualization_timeline.ini
@@ -1,6 +1,6 @@
-; 
-; Copyright (C) 2005 - 2012 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Fabrik 3.0
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_VIZ_TIMELINE_BAND_AS_OVERVIEW_DESC="If set to yes then event tiles are not shown, and marker style condensced"

--- a/plugins/fabrik_visualization/timeline/language/en-GB/en-GB.plg_fabrik_visualization_timeline.sys.ini
+++ b/plugins/fabrik_visualization/timeline/language/en-GB/en-GB.plg_fabrik_visualization_timeline.sys.ini
@@ -1,7 +1,6 @@
-;
 ; Fabrik 3.0
-; Copyright (C) 2005 - 2010 Pollen 8 Design Ltd. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
+; Copyright (C) 2005-2013 fabrikar.com - All rights reserved.. All rights reserved.
+; License GNU/GPL http://www.gnu.org/copyleft/gpl.html
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_FABRIK_VISUALIZATION_TIMELINE="Fabrik Visualization - Timeline"


### PR DESCRIPTION
Make copyright and license consistent in en-gb string files.

Add blank line at bottom to avoid Git warnings.
