### PR TITLE
Fix List Details / Filters / Search All yesno 

### DIFF
--- a/administrator/components/com_fabrik/models/forms/list.xml
+++ b/administrator/components/com_fabrik/models/forms/list.xml
@@ -344,12 +344,12 @@
 			<field name="search-mode"
 				type="radio"
 				class="btn-group"
-				default="AND"
+				default="0"
 				label="COM_FABRIK_FIELD_VIEW_SEARCH_MODE_LABEL"
 				description="COM_FABRIK_FIELD_VIEW_SEARCH_MODE_DESC"
 			>
-				<option value="AND">JNO</option>
-				<option value="OR">JYES</option>
+				<option value="0">JNO</option>
+				<option value="1">JYES</option>
 			</field>
 			
 			<field name="search-mode-advanced"

--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -5538,7 +5538,9 @@ class FabrikFEModelList extends JModelForm
 		$filters = $this->getFilterArray();
 
 		$params = $this->getParams();
-		if ($params->get('search-mode', 'AND') == 'OR')
+		// Paul Switch to 0/1 for NO/YES from AND/OR so that bootstrap classes work but support legacy values
+		if (($params->get('search-mode', '0') == '1')
+		 || ($params->get('search-mode', '0') == 'OR'))
 		{
 			// One field to search them all (and in the darkness bind them)
 			$requestKey = $this->getFilterModel()->getSearchAllRequestKey();


### PR DESCRIPTION
Make Yes No field display like other bootstrap Yes No fields.

Retain support for legacy parameter settings.
