### PR TITLE
Moving form outro field before error message.

### DIFF
--- a/components/com_fabrik/models/listfilter.php
+++ b/components/com_fabrik/models/listfilter.php
@@ -1279,7 +1279,7 @@ class FabrikFEModelListfilter extends FabModel
 		$elements = $this->listModel->getElements('id');
 		$item = $this->listModel->getTable();
 		$identifier = $app->input->get('listref', $this->listModel->getRenderContext());
-		//$identifier = $this->listModel->getRenderContext();
+		$identifier = $this->listModel->getRenderContext();
 		$key = 'com_' . $package . '.list' . $identifier . '.filter';
 		$sessionfilters = JArrayHelper::fromObject($app->getUserState($key));
 		$filterkeys = array_keys($filters);


### PR DESCRIPTION
 It's belonging to intro, error message field is hard to find and may be overlayed by outro WYSIWYG editor

Listfilter fix as in 3.1
