### PR TITLE
Update php.php

### DIFF
--- a/plugins/fabrik_validationrule/php/php.php
+++ b/plugins/fabrik_validationrule/php/php.php
@@ -96,7 +96,6 @@ class PlgFabrik_ValidationrulePhp extends PlgFabrik_Validationrule
 		$phpCode = $params->get('php-code');
 		$phpCode = $w->parseMessageForPlaceHolder($phpCode, $formData, true, true);
 		$retval = @eval($phpCode);
-		FabrikWorker::logEval($retval, 'Caught exception on php validation of ' . $elementModel->getFullName(true, false) . ': %s');
 		return $retval;
 	}
 }


### PR DESCRIPTION
if the php validation script eval return false, it's not inevitably because the script fails but because the validation script return false. So we don't have to raise a script error
