### PR TITLE
Update php.php

### DIFF
--- a/plugins/fabrik_validationrule/php/php.php
+++ b/plugins/fabrik_validationrule/php/php.php
@@ -96,7 +96,8 @@ class PlgFabrik_ValidationrulePhp extends PlgFabrik_Validationrule
 		$phpCode = $params->get('php-code');
 		$phpCode = $w->parseMessageForPlaceHolder($phpCode, $formData, true, true);
 		$retval = @eval($phpCode);
-		FabrikWorker::logEval($retval, 'Caught exception on php validation of ' . $elementModel->getFullName(true, false) . ': %s');
+		// @TODO: find a solution to distinguish if the eval function return false because of the script php or because of a syntax error.
+		//FabrikWorker::logEval($retval, 'Caught exception on php validation of ' . $elementModel->getFullName(true, false) . ': %s');
 		return $retval;
 	}
 }


### PR DESCRIPTION
If the php validation script eval return false, It's not inevitably because the script fails but because the validation script return false. So we don't have to raise a script error.
We'd have to find a solution to distinguish if the eval function return false because of the script php or because of a syntax error.
