### PR TITLE
details bootstrap template

### DIFF
--- a/components/com_fabrik/views/details/tmpl/bootstrap/default_group_labels_above.php
+++ b/components/com_fabrik/views/details/tmpl/bootstrap/default_group_labels_above.php
@@ -14,7 +14,9 @@ defined('_JEXEC') or die('Restricted access');
 
 $element = $this->element;?>
 <div class=" <?php echo $element->containerClass . $element->span; ?>">
-	<?php echo $element->label;?>
+	<div class="fabrikLabel">
+		<?php echo $element->label_raw;?>
+	</div>
 
 	<?php if ($this->tipLocation == 'above') : ?>
 		<span class="help-block"><?php echo $element->tipAbove ?></span>

--- a/components/com_fabrik/views/details/tmpl/bootstrap/default_group_labels_side.php
+++ b/components/com_fabrik/views/details/tmpl/bootstrap/default_group_labels_side.php
@@ -14,8 +14,8 @@ defined('_JEXEC') or die('Restricted access');
 
 $element = $this->element;
 ?>
-<div class="<?php echo $element->span; ?>">
-	<div class="span4">
+<div class="<?php echo $element->containerClass . $element->span;?>">
+	<div class="span4 fabrikLabel">
 		<?php echo $element->label_raw;?>
 	</div>
 	<div class="span8">


### PR DESCRIPTION
details label-above: no label[for] in details view (accessibility error) (as in labels-side)
details label-side: containerClass to surrounding div (as in labels-above)
class fabrikLabel added to both
