### PR TITLE
update string.php line 242 (<= instead of <)

### DIFF
--- a/components/com_fabrik/helpers/string.php
+++ b/components/com_fabrik/helpers/string.php
@@ -239,7 +239,7 @@ class FabrikString extends JString
 	{
 		// Replace umlauts
 		$out = '';
-		for ($i = 0; $i < JString::strlen($str); $i++)
+		for ($i = 0; $i <= JString::strlen($str); $i++)
 		{
 			$ch = ord($str{$i});
 			switch ($ch)


### PR DESCRIPTION
Used in list view with icon replacement feature. For example, if the value is "Création", the ord function in line 244 find 195 for the "é" thus striping it out as well as missing the last car. The result is "Cratio". The "replace umlauts" should not be necessary with the iconv function. Also the $fromEnc shouldn't be set dynamically according to the current localization ? Currently it miss the "é" to "e" replacement....
