### PR TITLE
Moving form outro back under params

### DIFF
--- a/administrator/components/com_fabrik/models/forms/form.xml
+++ b/administrator/components/com_fabrik/models/forms/form.xml
@@ -27,15 +27,6 @@
 			label="COM_FABRIK_FIELD_INTRODUCTION_LABEL"
 			description="COM_FABRIK_FIELD_INTRODUCTION_DESC" />
 		
-		<field name="outro" 
-			type="editor"
-			filter="FabrikAdminHelper::filterText"
-			rows="3" 
-			cols="6" 
-			label="COM_FABRIK_FIELD_OUTRO_LABEL"
-			description="COM_FABRIK_FIELD_OUTRO_DESC" />
-			
-			
 		<field name="error" 
 			type="text"
 			size="40" 
@@ -91,6 +82,18 @@
 	
 	<fields name="params">
 	
+		<fieldset name="details2">
+		
+			<field name="outro" 
+				type="editor"
+				filter="FabrikAdminHelper::filterText"
+				rows="3" 
+				cols="6" 
+				label="COM_FABRIK_FIELD_OUTRO_LABEL"
+				description="COM_FABRIK_FIELD_OUTRO_DESC" />
+				
+		</fieldset>
+
 		<fieldset name="buttons">
 		
 			<field name="reset_button" 


### PR DESCRIPTION
Wasn't good idea to move outro out from params as then form admin couldn't save new outro or display existing one.
