### PR TITLE
Fixed bad pass tables in URL

### DIFF
--- a/plugins/fabrik_form/redirect/redirect.php
+++ b/plugins/fabrik_form/redirect/redirect.php
@@ -293,7 +293,7 @@ class PlgFabrik_FormRedirect extends PlgFabrik_Form
 		{
 			foreach ($val as $v)
 			{
-				$this->_appendQS($queryvars, "{$key}[value]", $v);
+				$this->_appendQS($queryvars, "{$key}[]", $v);
 			}
 		}
 		else


### PR DESCRIPTION
The values ​​of a checkbox element are all placed on the same index "value" table => Only the last value can be retrieved from the target page.
