### PR TITLE
Fix validation plugins when error message is blank.

### DIFF
--- a/components/com_fabrik/models/validation_rule.php
+++ b/components/com_fabrik/models/validation_rule.php
@@ -117,7 +117,7 @@ class PlgFabrik_Validationrule extends FabrikPlugin
 		}
 		$params = $this->getParams();
 		$v = $params->get($this->pluginName . '-message');
-		if ($v === '')
+		if (empty($v))
 		{
 			$v = 'COM_FABRIK_FAILED_VALIDATION';
 		}


### PR DESCRIPTION
$v is null not '' so switch to using empty function.

Fixes problem reported in http://fabrikar.com/forums/index.php?threads/validation-error-highlighting.35653/page-2 with notempty validation.
