### PR TITLE
NumChecked JS method for dbjoin as multi-checkbox

### DIFF
--- a/plugins/fabrik_element/databasejoin/databasejoin.js
+++ b/plugins/fabrik_element/databasejoin/databasejoin.js
@@ -493,7 +493,7 @@ var FbDatabasejoin = new Class({
 			return null;
 		}
 		return this._getSubElements().filter(function (c) {
-			return c.checked;
+			return c.value !== "0" ? c.checked : false;
 		}).length;
 	},
 


### PR DESCRIPTION
This fix copies the numChecked function from checkbox to dbjoin when used as a multi-checkbox.

This should be able to be ported back to Fabrik 3.0.

Fixes issue in http://fabrikar.com/forums/index.php?threads/limit-the-number-of-responses-in-databasejoin-checkbox.35769/
