### PR TITLE
Fix php fatal error in j25 list pagination

### DIFF
--- a/components/com_fabrik/helpers/pagination.php
+++ b/components/com_fabrik/helpers/pagination.php
@@ -477,9 +477,13 @@ class FPagination extends JPagination
 			}
 			return $default;
 		}
+		elseif (isset($this->$property))
+		{
+			return $this->$property;
+		}
 		else
 		{
-			return $this->get($property, $default);
+			return $default;
 		}
 	}
 


### PR DESCRIPTION
This is the error generated in J2.5 using F3.1:

```
 Fatal error:  Maximum function nesting level of '100' reached, aborting! 
```
