### PR TITLE
Improve autocomplete

### DIFF
--- a/media/com_fabrik/js/autocomplete-bootstrap.js
+++ b/media/com_fabrik/js/autocomplete-bootstrap.js
@@ -1,5 +1,5 @@
 /**
- * Bootstrap Auto-Complete
+ * Auto-Complete
  *
  * @copyright: Copyright (C) 2005-2013, fabrikar.com - All rights reserved.
  * @license:   GNU/GPL http://www.gnu.org/copyleft/gpl.html
@@ -27,16 +27,12 @@ var FbAutocomplete = new Class({
 
 	initialize: function (element, options) {
 		window.addEvent('domready', function () {
-			this.matchedResult = false;
 			this.setOptions(options);
 			element = element.replace('-auto-complete', '');
 			this.options.labelelement = typeOf(document.id(element + '-auto-complete')) === "null" ? document.getElement(element + '-auto-complete') : document.id(element + '-auto-complete');
 			this.cache = {};
-			this.selected = -1;
-			this.mouseinsde = false;
-			document.addEvent('keydown', function (e) {
-				this.doWatchKeys(e);
-			}.bind(this));
+			this.selected = -2;
+			this.searchText = '';
 			this.element = typeOf(document.id(element)) === "null" ? document.getElement(element) : document.id(element);
 			this.buildMenu();
 			if (!this.getInputElement()) {
@@ -44,105 +40,141 @@ var FbAutocomplete = new Class({
 				return;
 			}
 			this.getInputElement().setProperty('autocomplete', 'off');
+			this.getInputElement().addEvent('keydown', function (e) {
+				this.doWatchKeys(e);
+			}.bind(this));
 			this.getInputElement().addEvent('keyup', function (e) {
 				this.search(e);
 			}.bind(this));
-
+			// We need to prevent blur propagation so that menu clicks don't trigger other blur events
 			this.getInputElement().addEvent('blur', function (e) {
-				if (this.options.storeMatchedResultsOnly) {
-					if (!this.matchedResult) {
-						if (typeof(this.data) === 'undefined' || !(this.data.length === 1 && this.options.autoLoadSingleResult)) {
-							this.element.value = '';
-						}
-					}
-				}
+				e.stop();
 			}.bind(this));
 		}.bind(this));
 	},
 
 	search: function (e) {
+		if (this.ajax) {
+			this.ajax.cancel();
+		}
+		var v = this.getInputElement().get('value');
 		if (e.key === 'tab' || e.key === 'enter') {
-			e.stop();
-			this.closeMenu();
-			if (this.ajax) {
-				this.ajax.cancel();
-			}
+			this.searchText = v.toLowerCase();
+			this.menuClose();
 			this.element.fireEvent('change', new Event.Mock(this.element, 'change'), 500);
 			return;
 		}
-		this.matchedResult = false;
-		var v = this.getInputElement().get('value');
 		if (v === '') {
-			this.element.value = '';
-		}
-		if (v !== this.searchText && v !== '') {
-			if (this.options.storeMatchedResultsOnly === false) {
+			this.menuClose();
+			this.searchText = this.element.value = '';
+		} else if (v.toLowerCase() !== this.searchText) {
+			if (this.options.storeMatchedResultsOnly) {
+				this.element.value = '';
+			} else {
 				this.element.value = v;
 			}
-			this.positionMenu();
-			if (this.cache[v]) {
-				this.populateMenu(this.cache[v]);
-				this.openMenu();
-			} else {
-				if (this.ajax) {
-					this.closeMenu();
-					this.ajax.cancel();
+			if (this.cache['$' + v.toLowerCase() + '$']) {
+				this.searchText = v.toLowerCase();
+				this.menuPopulateOpen(this.cache['$' + v.toLowerCase() + '$']);
+			} else if (this.searchText !== '' && v.indexOf(' ') < 0 && v.indexOf(this.searchText) >= 0) {
+				/**
+				 * If this search doesn't have any spaces in ...
+				 * And if last search is a subset of this search then ...
+				 * The results for this search will be a subset of the results of the last search
+				 * In which case we can simply loop through the results of the last search and
+				 * delete results where this search is not inside. And we can then cache this.
+				 **/
+				var r = this.cache['$' + this.searchText + '$'];
+				var u = v.toLowerCase();
+				for (var i=r.length - 1; i >= 0; i--) {
+					if (r[i].text.toLowerCase().indexOf(u) < 0) {
+						r.splice(i, 1);
+					}
 				}
+				this.completeAjax(r, v);
+			} else {
 				this.ajax = new Request({
 					url: this.options.url,
 					data: {
 						value: v
 					},
-					onRequest: function () {
+
+					onRequest: function(){
 						Fabrik.loader.start(this.getInputElement());
 					}.bind(this),
-					onCancel: function () {
+
+					onCancel: function(){
 						Fabrik.loader.stop(this.getInputElement());
 						this.ajax = null;
 					}.bind(this),
-					onSuccess: function (e) {
+
+					onComplete: function(){
 						Fabrik.loader.stop(this.getInputElement());
 						this.ajax = null;
-						if (typeOf(e) === 'null') {
+					}.bind(this),
+
+					onFailure: function(xhr){
+						fconsole('Fabrik autocomplete: Ajax failure: Code ' + xhr.status + ': ' + xhr.statusText);
+						var elModel = Fabrik.blocks[this.options.formRef].formElements.get(this.element.id);
+						elModel.setErrorMessage(Joomla.JText._('COM_FABRIK_AUTOCOMPLETE_AJAX_ERROR'), 'fabrikError', true);
+					}.bind(this),
+
+					onSuccess: function (r) {
+						if (typeOf(r) === 'null') {
 							fconsole('Fabrik autocomplete: Ajax response empty');
 							var elModel = Fabrik.blocks[this.options.formRef].formElements.get(this.element.id);
 							elModel.setErrorMessage(Joomla.JText._('COM_FABRIK_AUTOCOMPLETE_AJAX_ERROR'), 'fabrikError', true);
 							return;
 						}
-						this.completeAjax(e, v);
-					}.bind(this),
-					onFailure: function(xhr){
-						Fabrik.loader.stop(this.getInputElement());
-						this.ajax = null;
-						fconsole('Fabrik autocomplete: Ajax failure: Code ' + xhr.status + ': ' + xhr.statusText);
-						var elModel = Fabrik.blocks[this.options.formRef].formElements.get(this.element.id);
-						elModel.setErrorMessage(Joomla.JText._('COM_FABRIK_AUTOCOMPLETE_AJAX_ERROR'), 'fabrikError', true);
+						r = JSON.decode(r);
+						this.completeAjax(r, v);
 					}.bind(this)
 				}).send();
 			}
 		}
-		this.searchText = v;
 	},
 
 	completeAjax: function (r, v) {
-		r = JSON.decode(r);
-		this.cache[v] = r;
-		this.populateMenu(r);
-		this.openMenu();
+		var u = this.searchText = v.toLowerCase();
+		this.cache['$' + u + '$'] = r;
+		if (r.length === 1) {
+			// Cache additional v with remaining characters appended one by one because we know the answer already
+			// e.g. user types abr on a 'contains' dbjoin and only returned word is fabrik, then we cache
+			// additionally abri and abrik. Since abr is unique, then so also is fabr as well as abri and abrik.
+			var w = r[0].text.toLowerCase();
+			this.searchText = w.substr(0, w.indexOf(u) + u.length);
+			var x = w.substr(w.indexOf(u));
+			while (x.length > u.length) {
+				this.cache['$' + w + '$'] = r;
+				w = w.substr(0, w.length - 1);
+				this.cache['$' + x + '$'] = r;
+				x = x.substr(0, x.length - 1);
+			}
+		} else {
+			// Cache each item in the list so if we select one and tab back we don't ajax again.
+			r.each(function(s) {
+				this.cache['$' + s.text.toLowerCase() + '$'] = Array(s);
+			}.bind(this));
+		}
+		this.menuPopulateOpen(r);
 	},
 
 	buildMenu: function ()
 	{
-		this.menu = new Element('ul.dropdown-menu', {'role': 'menu', 'styles': {'z-index': 1056}});
+		if (Fabrik.bootstrapped) {
+			this.menu = new Element('ul.' + this.options.classes.ul, {'role': 'menu', 'styles': {'z-index': 1056}});
+			this.ul = this.menu;
+		} else {
+			this.menu = new Element('div', {'class': this.options.menuclass, 'styles': {'position': 'absolute'}}).adopt(new Element('ul.' + this.options.classes.ul));
+			this.ul = this.menu.getElement('ul');
+		}
 		this.menu.inject(document.body);
-		this.menu.addEvent('mouseenter', function () {
-			this.mouseinsde = true;
-		}.bind(this));
-		this.menu.addEvent('mouseleave', function () {
-			this.mouseinsde = false;
-		}.bind(this));
 		this.menu.addEvent('click:relay(a)', function (e, target) {
 			this.makeSelection(e, target);
+		}.bind(this));
+		// Paul Make mouseover select the li like a down key would.
+		this.menu.addEvent('mouseenter:relay(li)', function (e, target) {
+			this.selectLi(e, target);
 		}.bind(this));
 	},
 
@@ -152,90 +184,121 @@ var FbAutocomplete = new Class({
 
 	positionMenu: function () {
 		var coords = this.getInputElement().getCoordinates();
-		// var pos = this.getInputElement().getPosition();
 		this.menu.setStyles({ 'left': coords.left, 'top': (coords.top + coords.height) - 1, 'width': coords.width});
 	},
 
-	populateMenu: function (data) {
+	menuPopulateOpen: function (data) {
 		// $$$ hugh - added decoding of things like &amp; in the text strings
-		var li, a;
 		data.map(function (item, index) {
 			item.text = Encoder.htmlDecode(item.text);
 			return item;
 		});
 		this.data = data;
 		var max = this.getListMax();
-		var ul = this.menu;
+		var ul = this.ul;
 		ul.empty();
-		if (data.length === 1 && this.options.autoLoadSingleResult) {
-			this.element.value = data[0].value;
-			// $$$ Paul - The selection event is for text being selected in an input field not for a link being selected
-			this.fireEvent('selection', [this, this.element.value]);
-		}
 		if (data.length === 0) {
-			li = new Element('li').adopt(new Element('div.alert.alert-info').adopt(new Element('i').set('text', Joomla.JText._('COM_FABRIK_NO_RECORDS'))));
-			li.inject(ul);
+			new Element('li').adopt(new Element('div.alert.alert-info').adopt(new Element('i').set('text', Joomla.JText._('COM_FABRIK_NO_RECORDS')))).inject(ul);
 		}
 		for (var i = 0; i < max; i ++) {
 			var pair = data[i];
-			a = new Element('a', {'href': '#', 'data-value': pair.value, tabindex: '-1'}).set('text', pair.text);
-			li = new Element('li').adopt(a);
+			var a = new Element('a', {'href': '#', 'data-value': pair.value, tabindex: '-1'}).set('text', pair.text);
+			if (!Fabrik.bootstrapped) {
+				li.addClass('unselected ' + this.options.classes.li);
+			}
+			var li = new Element('li').adopt(a);
 			li.inject(ul);
 		}
 		if (data.length > this.options.max) {
 			new Element('li').set('text', '....').inject(ul);
 		}
+		if (data.length === 1 && this.options.autoLoadSingleResult) {
+			var v = this.getInputElement().get('value');
+			var r = data[0].text;
+			i = r.toLowerCase().indexOf(v.toLowerCase());
+			if (i >=0)
+			{
+				var ie = this.getInputElement();
+				ie.value = r;
+				ie.selectRange(i + v.length, r.length);
+				this.element.value = data[0].value;
+				this.menuClose();
+				// $$$ Paul - The selection event is for text being selected in an input field not for a link being selected
+				// this.fireEvent('selection', [this, this.element.value]);
+				return;
+			}
+		}
+		this.menuOpen();
+	},
+
+	selectLi: function (e, mouseLi) {
+		if (typeOf(mouseLi) !== 'null') {
+			this.menu.getElements('li').each(function (li, i) {
+				if (li === mouseLi) {
+					this.selected = i;
+					this.highlight();
+				}
+			}.bind(this));
+		}
 	},
 
 	makeSelection: function (e, li) {
-		e.preventDefault();
+		e.stop();
+		this.getInputElement().focus();
 		// $$$ tom - make sure an item was selected before operating on it.
 		if (typeOf(li) !== 'null') {
-			this.getInputElement().value = li.get('text');
+			/**
+			 * Blur is triggered by mouse click (which takes focus from input element)
+			 * and triggers form ajax element validation events.
+			 * We have added a delay of 500ms to validation events in form.js to allow the fields to be set here
+			 * however if validation fails because it is triggered before fields are set, then increase the delay.
+			 **/
 			this.element.value = li.getProperty('data-value');
-			this.closeMenu();
-			this.fireEvent('selection', [this, this.element.value]);
-			// $$$ hugh - need to fire change event, in case it's something like a join element
-			// with a CDD that watches it.
-			this.element.fireEvent('change', new Event.Mock(this.element, 'change'), 700);
+			this.getInputElement().value = li.get('text');
+			this.menuClose();
+			// $$$ Paul - The selection event is for text being selected in an input field not for a link being selected
+			// this.fireEvent('selection', [this, this.element.value]);
 			// $$$ hugh - fire a Fabrik event, just for good luck.  :)
 			Fabrik.fireEvent('fabrik.autocomplete.selected', [this, this.element.value]);
+			// $$$ hugh - fire a change event in case it's e.g. a join element with a CDD watching it.
+			this.element.fireEvent('change', new Event.Mock(this.element, 'change'), 100);
 		} else {
 			/**
 			 * $$$ Paul - The Fabrik event below makes NO sense.
 			 * This is a code error condition not an event because typeOf(li) should never be null
 			 **/
-			//  $$$ tom - fire a notselected event to let developer take appropriate actions.
+			// $$$ tom - fire a notselected event to let developer take appropriate actions.
 			Fabrik.fireEvent('fabrik.autocomplete.notselected', [this, this.element.value]);
 		}
 	},
 
-	closeMenu: function () {
+	menuClose: function () {
 		if (this.shown) {
 			this.shown = false;
-			this.menu.hide();
-			this.selected = -1;
-			document.removeEvent('click', function (e) {
-				this.doTestMenuClose(e);
-			}.bind(this));
+			if (Fabrik.bootstrapped) {
+				this.menu.hide();
+			} else {
+				this.menu.fade('out');
+			}
+			this.selected = -2;
 		}
 	},
 
-	openMenu: function () {
+	menuOpen: function () {
 		if (!this.shown) {
-			this.menu.show();
 			this.shown = true;
-			document.addEvent('click', function (e) {
-				this.doTestMenuClose(e);
-			}.bind(this));
-			this.selected = 0;
-			this.highlight();
-		}
-	},
-
-	doTestMenuClose: function () {
-		if (!this.mouseinsde) {
-			this.closeMenu();
+			this.positionMenu();
+			if (Fabrik.bootstrapped) {
+				this.menu.show();
+			} else {
+				this.menu.setStyle('visibility', 'visible').fade('in');
+			}
+			if (this.data.length > 0) {
+				this.selected = -1;
+				this.highlight();
+			} else {
+				this.selected = -2;
+			}
 		}
 	},
 
@@ -249,49 +312,38 @@ var FbAutocomplete = new Class({
 	doWatchKeys: function (e) {
 		var max = this.getListMax(), selected, selectEvnt;
 		if (!this.shown) {
-			// Stop enter from submitting when in in-line edit form.
-			if (e.code.toInt() === 13) {
-				e.stop();
-			}
-			if (e.code.toInt() === 40 && document.activeElement === this.getInputElement()) {
-				this.openMenu();
+			if (e.code.toInt() === 40 && this.getInputElement().get('value') !== '') {
+				this.menuOpen();
 			}
 		} else {
-			if (e.key === 'enter' || e.key === 'tab') {
-				window.fireEvent('blur');
-			}
 			switch (e.code) {
-			case 40://down
-				if (!this.shown) {
-					this.openMenu();
-				}
-				if (this.selected + 1 <= max) {
-					this.selected ++;
-				}
-				this.highlight();
-				e.stop();
-				break;
-			case 38: //up
-				if (this.selected - 1 >= -1) {
-					this.selected --;
-					this.highlight();
-				}
-				e.stop();
-				break;
-			case 13://enter
-			case 9://tab
-				e.stop();
-				selected = this.getSelected();
-				if (selected) {
-					selectEvnt = new Event.Mock(selected, 'click');
-					this.makeSelection(selectEvnt, selected);
-					this.closeMenu();
-				}
-				break;
-			case 27://escape
-				e.stop();
-				this.closeMenu();
-				break;
+				case 40: // down
+					e.stop();
+					if (this.selected >= -1 && this.selected < max - 1) {
+						this.selected ++;
+						this.highlight();
+					}
+					break;
+				case 38: // up
+					e.stop();
+					if (this.selected > -1) {
+						this.selected --;
+						this.highlight();
+					}
+					break;
+				case 13: // enter
+					e.stop();
+					/* falls through */
+				case 9:  // tab
+					if (this.shown) {
+						this.makeSelection(new Event.Mock(this.getSelected(), 'click'), this.getSelected());
+						this.menuClose();
+					}
+					break;
+				case 27: // escape
+					e.stop();
+					this.menuClose();
+					break;
 			}
 		}
 	},
@@ -318,16 +370,22 @@ var FbAutocomplete = new Class({
 	},
 
 	highlight: function () {
-		this.matchedResult = true;
 		this.menu.getElements('li').each(function (li, i) {
-			if (i === this.selected) {
-				li.addClass('selected').addClass('active');
+			if (Fabrik.bootstrapped) {
+				if (i === this.selected) {
+					li.addClass('selected').addClass('active');
+				} else {
+					li.removeClass('selected').removeClass('active');
+				}
 			} else {
-				li.removeClass('selected').removeClass('active');
+				if (i === this.selected) {
+					li.addClass('selected').addClass('active');
+				} else {
+					li.removeClass('selected').removeClass('active');
+				}
 			}
 		}.bind(this));
 	}
-
 });
 
 var FabCddAutocomplete = new Class({
@@ -335,59 +393,65 @@ var FabCddAutocomplete = new Class({
 	Extends: FbAutocomplete,
 
 	search: function (e) {
-		var key;
 		var v = this.getInputElement().get('value');
 		if (v === '') {
 			this.element.value = '';
 		}
-		if (v !== this.searchText && v !== '') {
+		if (v.toLowerCase() !== this.searchText && v !== '') {
 			var observer = document.id(this.options.observerid);
-			if (typeOf(observer) !== 'null') {
-				if (this.options.formRef) {
-					observer = Fabrik.blocks[this.options.formRef].formElements[this.options.observerid];
-				}
-				key = observer.get('value') + '.' + v;
-			} else {
+			if (typeOf(observer) === 'null') {
 				this.parent(e);
 				return;
 			}
-			this.positionMenu();
-			if (this.cache[key]) {
-				this.populateMenu(this.cache[key]);
-				this.openMenu();
+			if (this.options.formRef) {
+				observer = Fabrik.blocks[this.options.formRef].formElements[this.options.observerid];
+			}
+			this.searchText = v.toLowerCase();
+			var key = observer.get('value') + '.' + v;
+			if (this.cache['$' + key + '$']) {
+				this.menuPopulateOpen(this.cache['$' + key + '$']);
 			} else {
 				if (this.ajax) {
-					this.closeMenu();
+					Fabrik.loader.stop(this.getInputElement());
+					this.menuClose();
 					this.ajax.cancel();
 				}
 				this.ajax = new Request({
 					url : this.options.url,
+					method: this.options.ajaxmethod,
 					data: {
 						value: v,
 						fabrik_cascade_ajax_update: 1,
 						v: observer.get('value')
 					},
+
 					onRequest: function () {
 						Fabrik.loader.start(this.getInputElement());
 					}.bind(this),
+
 					onCancel: function () {
 						Fabrik.loader.stop(this.getInputElement());
 					}.bind(this),
-					onSuccess: function (e) {
+
+					onComplete: function(){
 						Fabrik.loader.stop(this.getInputElement());
 						this.ajax = null;
-						this.completeAjax(e);
 					}.bind(this),
+
 					onFailure: function (xhr) {
 						Fabrik.loader.stop(this.getInputElement());
 						this.ajax = null;
 						fconsole('Fabrik autocomplete: Ajax failure: Code ' + xhr.status + ': ' + xhr.statusText);
 						var elModel = Fabrik.blocks[this.options.formRef].formElements.get(this.element.id);
 						elModel.setErrorMessage(Joomla.JText._('COM_FABRIK_AUTOCOMPLETE_AJAX_ERROR'), 'fabrikError', true);
+					}.bind(this),
+
+					onSuccess: function (r) {
+						r = JSON.decode(r);
+						this.completeAjax(r, v);
 					}.bind(this)
 				}).send();
 			}
 		}
-		this.searchText = v;
 	}
 });

--- a/media/com_fabrik/js/autocomplete.js
+++ b/media/com_fabrik/js/autocomplete.js
@@ -6,16 +6,16 @@
  */
 
 /*jshint mootools: true */
-/*global Fabrik:true, fconsole:true, Joomla:true, CloneObject:true, $H:true,unescape:true */
+/*global Fabrik:true, fconsole:true, Joomla:true, $H:true, Encoder:true */
 
 var FbAutocomplete = new Class({
 
 	Implements: [Options, Events],
 
 	options: {
-		menuclass: 'auto-complete-container',
+		menuclass: 'auto-complete-container dropdown',
 		classes: {
-			'ul': 'results',
+			'ul': 'dropdown-menu',
 			'li': 'result'
 		},
 		url: 'index.php',
@@ -26,94 +26,155 @@ var FbAutocomplete = new Class({
 	},
 
 	initialize: function (element, options) {
-		this.matchedResult = false;
-		this.setOptions(options);
-		this.options.labelelement = typeOf(document.id(element + '-auto-complete')) === "null" ? document.getElement(element + '-auto-complete') : document.id(element + '-auto-complete');
-		this.cache = {};
-		this.selected = -1;
-		this.mouseinsde = false;
-		document.addEvent('keydown', function (e) {
-			this.doWatchKeys(e);
-		}.bind(this));
-		this.element = typeOf(document.id(element)) === "null" ? document.getElement(element) : document.id(element);
-		this.buildMenu();
-		if (!this.getInputElement()) {
-			fconsole('autocomplete didnt find input element');
-			return;
-		}
-		this.getInputElement().setProperty('autocomplete', 'off');
-		this.getInputElement().addEvent('keyup', function (e) {
-			this.search(e);
-		}.bind(this));
-
-		this.getInputElement().addEvent('blur', function (e) {
-			if (this.options.storeMatchedResultsOnly) {
-				if (!this.matchedResult) {
-					if (!(this.data.length === 1 && this.options.autoLoadSingleResult)) {
-						this.element.value = '';
-					}
-				}
+		window.addEvent('domready', function () {
+			this.setOptions(options);
+			element = element.replace('-auto-complete', '');
+			this.options.labelelement = typeOf(document.id(element + '-auto-complete')) === "null" ? document.getElement(element + '-auto-complete') : document.id(element + '-auto-complete');
+			this.cache = {};
+			this.selected = -2;
+			this.searchText = '';
+			this.element = typeOf(document.id(element)) === "null" ? document.getElement(element) : document.id(element);
+			this.buildMenu();
+			if (!this.getInputElement()) {
+				fconsole('autocomplete didn\'t find input element');
+				return;
 			}
+			this.getInputElement().setProperty('autocomplete', 'off');
+			this.getInputElement().addEvent('keydown', function (e) {
+				this.doWatchKeys(e);
+			}.bind(this));
+			this.getInputElement().addEvent('keyup', function (e) {
+				this.search(e);
+			}.bind(this));
+			// We need to prevent blur propagation so that menu clicks don't trigger other blur events
+			this.getInputElement().addEvent('blur', function (e) {
+				e.stop();
+			}.bind(this));
 		}.bind(this));
-
 	},
 
 	search: function (e) {
+		if (this.ajax) {
+			this.ajax.cancel();
+		}
+		var v = this.getInputElement().get('value');
 		if (e.key === 'tab' || e.key === 'enter') {
-			e.stop();
-			this.closeMenu();
+			this.searchText = v.toLowerCase();
+			this.menuClose();
+			this.element.fireEvent('change', new Event.Mock(this.element, 'change'), 500);
 			return;
 		}
-		this.matchedResult = false;
-		var v = this.getInputElement().get('value');
 		if (v === '') {
-			this.element.value = '';
-		}
-		if (v !== this.searchText && v !== '') {
-			if (this.options.storeMatchedResultsOnly === false) {
+			this.menuClose();
+			this.searchText = this.element.value = '';
+		} else if (v.toLowerCase() !== this.searchText) {
+			if (this.options.storeMatchedResultsOnly) {
+				this.element.value = '';
+			} else {
 				this.element.value = v;
 			}
-			this.positionMenu();
-			if (this.cache[v]) {
-				this.populateMenu(this.cache[v]);
-				this.openMenu();
-			} else {
-				Fabrik.loader.start(this.getInputElement());
-				if (this.ajax) {
-					this.closeMenu();
-					this.ajax.cancel();
+			if (this.cache['$' + v.toLowerCase() + '$']) {
+				this.searchText = v.toLowerCase();
+				this.menuPopulateOpen(this.cache['$' + v.toLowerCase() + '$']);
+			} else if (this.searchText !== '' && v.indexOf(' ') < 0 && v.indexOf(this.searchText) >= 0) {
+				/**
+				 * If this search doesn't have any spaces in ...
+				 * And if last search is a subset of this search then ...
+				 * The results for this search will be a subset of the results of the last search
+				 * In which case we can simply loop through the results of the last search and
+				 * delete results where this search is not inside. And we can then cache this.
+				 **/
+				var r = this.cache['$' + this.searchText + '$'];
+				var u = v.toLowerCase();
+				for (var i=r.length - 1; i >= 0; i--) {
+					if (r[i].text.toLowerCase().indexOf(u) < 0) {
+						r.splice(i, 1);
+					}
 				}
-				this.ajax = new Request({url: this.options.url,
+				this.completeAjax(r, v);
+			} else {
+				this.ajax = new Request({
+					url: this.options.url,
 					data: {
 						value: v
 					},
-					onComplete: function (e) {
+
+					onRequest: function(){
+						Fabrik.loader.start(this.getInputElement());
+					}.bind(this),
+
+					onCancel: function(){
 						Fabrik.loader.stop(this.getInputElement());
-						this.completeAjax(e, v);
+						this.ajax = null;
+					}.bind(this),
+
+					onComplete: function(){
+						Fabrik.loader.stop(this.getInputElement());
+						this.ajax = null;
+					}.bind(this),
+
+					onFailure: function(xhr){
+						fconsole('Fabrik autocomplete: Ajax failure: Code ' + xhr.status + ': ' + xhr.statusText);
+						var elModel = Fabrik.blocks[this.options.formRef].formElements.get(this.element.id);
+						elModel.setErrorMessage(Joomla.JText._('COM_FABRIK_AUTOCOMPLETE_AJAX_ERROR'), 'fabrikError', true);
+					}.bind(this),
+
+					onSuccess: function (r) {
+						if (typeOf(r) === 'null') {
+							fconsole('Fabrik autocomplete: Ajax response empty');
+							var elModel = Fabrik.blocks[this.options.formRef].formElements.get(this.element.id);
+							elModel.setErrorMessage(Joomla.JText._('COM_FABRIK_AUTOCOMPLETE_AJAX_ERROR'), 'fabrikError', true);
+							return;
+						}
+						r = JSON.decode(r);
+						this.completeAjax(r, v);
 					}.bind(this)
 				}).send();
 			}
 		}
-		this.searchText = v;
 	},
 
 	completeAjax: function (r, v) {
-		r = JSON.decode(r);
-		this.cache[v] = r;
-		Fabrik.loader.stop(this.getInputElement());
-		this.populateMenu(r);
-		this.openMenu();
+		var u = this.searchText = v.toLowerCase();
+		this.cache['$' + u + '$'] = r;
+		if (r.length === 1) {
+			// Cache additional v with remaining characters appended one by one because we know the answer already
+			// e.g. user types abr on a 'contains' dbjoin and only returned word is fabrik, then we cache
+			// additionally abri and abrik. Since abr is unique, then so also is fabr as well as abri and abrik.
+			var w = r[0].text.toLowerCase();
+			this.searchText = w.substr(0, w.indexOf(u) + u.length);
+			var x = w.substr(w.indexOf(u));
+			while (x.length > u.length) {
+				this.cache['$' + w + '$'] = r;
+				w = w.substr(0, w.length - 1);
+				this.cache['$' + x + '$'] = r;
+				x = x.substr(0, x.length - 1);
+			}
+		} else {
+			// Cache each item in the list so if we select one and tab back we don't ajax again.
+			r.each(function(s) {
+				this.cache['$' + s.text.toLowerCase() + '$'] = Array(s);
+			}.bind(this));
+		}
+		this.menuPopulateOpen(r);
 	},
 
 	buildMenu: function ()
 	{
-		this.menu = new Element('div', {'class': this.options.menuclass, 'styles': {'position': 'absolute'}}).adopt(new Element('ul', {'class': this.options.classes.ul}));
+		if (Fabrik.bootstrapped) {
+			this.menu = new Element('ul.' + this.options.classes.ul, {'role': 'menu', 'styles': {'z-index': 1056}});
+			this.ul = this.menu;
+		} else {
+			this.menu = new Element('div', {'class': this.options.menuclass, 'styles': {'position': 'absolute'}}).adopt(new Element('ul.' + this.options.classes.ul));
+			this.ul = this.menu.getElement('ul');
+		}
 		this.menu.inject(document.body);
-		this.menu.addEvent('mouseenter', function () {
-			this.mouseinsde = true;
+		this.menu.addEvent('click:relay(a)', function (e, target) {
+			this.makeSelection(e, target);
 		}.bind(this));
-		this.menu.addEvent('mouseleave', function () {
-			this.mouseinsde = false;
+		// Paul Make mouseover select the li like a down key would.
+		this.menu.addEvent('mouseenter:relay(li)', function (e, target) {
+			this.selectLi(e, target);
 		}.bind(this));
 	},
 
@@ -123,11 +184,10 @@ var FbAutocomplete = new Class({
 
 	positionMenu: function () {
 		var coords = this.getInputElement().getCoordinates();
-		var pos = this.getInputElement().getPosition();
 		this.menu.setStyles({ 'left': coords.left, 'top': (coords.top + coords.height) - 1, 'width': coords.width});
 	},
 
-	populateMenu: function (data) {
+	menuPopulateOpen: function (data) {
 		// $$$ hugh - added decoding of things like &amp; in the text strings
 		data.map(function (item, index) {
 			item.text = Encoder.htmlDecode(item.text);
@@ -135,73 +195,110 @@ var FbAutocomplete = new Class({
 		});
 		this.data = data;
 		var max = this.getListMax();
-		var ul = this.menu.getElement('ul');
+		var ul = this.ul;
 		ul.empty();
-		if (data.length === 1 && this.options.autoLoadSingleResult) {
-			this.matchedResult = true;
-			this.element.value = data[0].value;
-			this.fireEvent('selection', [this, this.element.value]);
+		if (data.length === 0) {
+			new Element('li').adopt(new Element('div.alert.alert-info').adopt(new Element('i').set('text', Joomla.JText._('COM_FABRIK_NO_RECORDS')))).inject(ul);
 		}
 		for (var i = 0; i < max; i ++) {
 			var pair = data[i];
-			var li = new Element('li', {'data-value': pair.value, 'class': 'unselected ' + this.options.classes.li}).set('text', pair.text);
+			var a = new Element('a', {'href': '#', 'data-value': pair.value, tabindex: '-1'}).set('text', pair.text);
+			if (!Fabrik.bootstrapped) {
+				li.addClass('unselected ' + this.options.classes.li);
+			}
+			var li = new Element('li').adopt(a);
 			li.inject(ul);
-			li.addEvent('click', function (e) {
-				e.stop();
-				this.makeSelection(e.target);
-			}.bind(this));
 		}
 		if (data.length > this.options.max) {
 			new Element('li').set('text', '....').inject(ul);
 		}
+		if (data.length === 1 && this.options.autoLoadSingleResult) {
+			var v = this.getInputElement().get('value');
+			var r = data[0].text;
+			i = r.toLowerCase().indexOf(v.toLowerCase());
+			if (i >=0)
+			{
+				var ie = this.getInputElement();
+				ie.value = r;
+				ie.selectRange(i + v.length, r.length);
+				this.element.value = data[0].value;
+				this.menuClose();
+				// $$$ Paul - The selection event is for text being selected in an input field not for a link being selected
+				// this.fireEvent('selection', [this, this.element.value]);
+				return;
+			}
+		}
+		this.menuOpen();
 	},
 
-	makeSelection: function (li) {
+	selectLi: function (e, mouseLi) {
+		if (typeOf(mouseLi) !== 'null') {
+			this.menu.getElements('li').each(function (li, i) {
+				if (li === mouseLi) {
+					this.selected = i;
+					this.highlight();
+				}
+			}.bind(this));
+		}
+	},
+
+	makeSelection: function (e, li) {
+		e.stop();
+		this.getInputElement().focus();
 		// $$$ tom - make sure an item was selected before operating on it.
 		if (typeOf(li) !== 'null') {
-			this.getInputElement().value = li.get('text');
+			/**
+			 * Blur is triggered by mouse click (which takes focus from input element)
+			 * and triggers form ajax element validation events.
+			 * We have added a delay of 500ms to validation events in form.js to allow the fields to be set here
+			 * however if validation fails because it is triggered before fields are set, then increase the delay.
+			 **/
 			this.element.value = li.getProperty('data-value');
-
-			this.matchedResult = true;
-			this.closeMenu();
-			this.fireEvent('selection', [this, this.element.value]);
-			// $$$ hugh - need to fire change event, in case it's something like a join element
-			// with a CDD that watches it.
-			this.element.fireEvent('change', new Event.Mock(this.element, 'change'), 700);
+			this.getInputElement().value = li.get('text');
+			this.menuClose();
+			// $$$ Paul - The selection event is for text being selected in an input field not for a link being selected
+			// this.fireEvent('selection', [this, this.element.value]);
 			// $$$ hugh - fire a Fabrik event, just for good luck.  :)
 			Fabrik.fireEvent('fabrik.autocomplete.selected', [this, this.element.value]);
+			// $$$ hugh - fire a change event in case it's e.g. a join element with a CDD watching it.
+			this.element.fireEvent('change', new Event.Mock(this.element, 'change'), 100);
 		} else {
-			//  $$$ tom - fire a notselected event to let developer take appropriate actions.
-            Fabrik.fireEvent('fabrik.autocomplete.notselected', [this, this.element.value]);
+			/**
+			 * $$$ Paul - The Fabrik event below makes NO sense.
+			 * This is a code error condition not an event because typeOf(li) should never be null
+			 **/
+			// $$$ tom - fire a notselected event to let developer take appropriate actions.
+			Fabrik.fireEvent('fabrik.autocomplete.notselected', [this, this.element.value]);
 		}
 	},
 
-	closeMenu: function () {
+	menuClose: function () {
 		if (this.shown) {
 			this.shown = false;
-			this.menu.fade('out');
-			this.selected = -1;
-			document.removeEvent('click', function (e) {
-				this.doTestMenuClose(e);
-			}.bind(this));
+			if (Fabrik.bootstrapped) {
+				this.menu.hide();
+			} else {
+				this.menu.fade('out');
+			}
+			this.selected = -2;
 		}
 	},
 
-	openMenu: function () {
+	menuOpen: function () {
 		if (!this.shown) {
 			this.shown = true;
-			this.menu.setStyle('visibility', 'visible').fade('in');
-			document.addEvent('click', function (e) {
-				this.doTestMenuClose(e);
-			}.bind(this));
-			this.selected = 0;
-			this.highlight();
-		}
-	},
-
-	doTestMenuClose: function () {
-		if (!this.mouseinsde) {
-			this.closeMenu();
+			this.positionMenu();
+			if (Fabrik.bootstrapped) {
+				this.menu.show();
+			} else {
+				this.menu.setStyle('visibility', 'visible').fade('in');
+			}
+			if (this.data.length > 0) {
+				this.selected = -1;
+				this.highlight();
+			} else {
+				this.selected = -2;
+			}
 		}
 	},
 
@@ -215,67 +312,71 @@ var FbAutocomplete = new Class({
 	doWatchKeys: function (e) {
 		var max = this.getListMax();
 		if (!this.shown) {
-			if (e.code.toInt() === 13) {
-				e.stop();
-			}
-			if (e.code.toInt() === 40 && document.activeElement === this.getInputElement()) {
-				this.openMenu();
+			if (e.code.toInt() === 40 && this.getInputElement().get('value') !== '') {
+				this.menuOpen();
 			}
 		} else {
-			if (e.key === 'enter' || e.key === 'tab') {
-				window.fireEvent('blur');
-			}
 			switch (e.code) {
-			case 40://down
-				if (!this.shown) {
-					this.openMenu();
-				}
-				if (this.selected + 1 < max) {
-					this.selected ++;
-					this.highlight();
-				}
-				e.stop();
-				break;
-			case 38: //up
-				if (this.selected - 1 >= -1) {
-					this.selected --;
-					this.highlight();
-				}
-				e.stop();
-				break;
-			case 13://enter
-			case 9://tab
-				e.stop();
-				var selectEvnt = new Event.Mock(this.getSelected(), 'click');
-				this.makeSelection(selectEvnt);
-				break;
-			case 27://escape
-				e.stop();
-				this.matchedResult = false;
-				this.closeMenu();
-				break;
+				case 40: // down
+					e.stop();
+					if (this.selected >= -1 && this.selected < max - 1) {
+						this.selected ++;
+						this.highlight();
+					}
+					break;
+				case 38: // up
+					e.stop();
+					if (this.selected > -1) {
+						this.selected --;
+						this.highlight();
+					}
+					break;
+				case 13: // enter
+					e.stop();
+					/* falls through */
+				case 9:  // tab
+					if (this.shown) {
+						this.makeSelection(new Event.Mock(this.getSelected(), 'click'), this.getSelected());
+						this.menuClose();
+					}
+					break;
+				case 27: // escape
+					e.stop();
+					this.menuClose();
+					break;
 			}
 		}
 	},
 
+	/**
+	 * Get the selected <a> tag
+	 *
+	 * @return  DOM Node <a>
+	 */
 	getSelected: function () {
-		var a = this.menu.getElements('li').filter(function (li, i) {
+		var lis = this.menu.getElements('li').filter(function (li, i) {
 			return i === this.selected;
 		}.bind(this));
-		return a[0];
+		return lis[0].getElement('a');
 	},
 
 	highlight: function () {
-		this.matchedResult = true;
 		this.menu.getElements('li').each(function (li, i) {
-			if (i === this.selected) {
-				li.addClass('selected');
+			if (Fabrik.bootstrapped) {
+				if (i === this.selected) {
+					li.addClass('selected').addClass('active');
+				} else {
+					li.removeClass('selected').removeClass('active');
+				}
 			} else {
-				li.removeClass('selected');
+				if (i === this.selected) {
+					li.addClass('selected').addClass('active');
+				} else {
+					li.removeClass('selected').removeClass('active');
+				}
 			}
 		}.bind(this));
 	}
-
 });
 
 var FabCddAutocomplete = new Class({
@@ -283,58 +384,59 @@ var FabCddAutocomplete = new Class({
 	Extends: FbAutocomplete,
 
 	search: function (e) {
-		var key;
 		var v = this.getInputElement().get('value');
 		if (v === '') {
 			this.element.value = '';
 		}
-		if (v !== this.searchText && v !== '') {
+		if (v.toLowerCase() !== this.searchText && v !== '') {
 			var observer = document.id(this.options.observerid);
-			if (typeOf(observer) !== 'null') {
-				key = observer.get('value') + '.' + v;
-			} else {
+			if (typeOf(observer) === 'null') {
 				this.parent(e);
 				return;
 			}
-			this.positionMenu();
-			if (this.cache[key]) {
-				this.populateMenu(this.cache[key]);
-				this.openMenu();
+			if (this.options.formRef) {
+				observer = Fabrik.blocks[this.options.formRef].formElements[this.options.observerid];
+			}
+			this.searchText = v.toLowerCase();
+			var key = observer.get('value') + '.' + v;
+			if (this.cache['$' + key + '$']) {
+				this.menuPopulateOpen(this.cache['$' + key + '$']);
 			} else {
-				Fabrik.loader.start(this.getInputElement());
-				if (this.ajax) {
-					this.closeMenu();
-					this.ajax.cancel();
-				}
-
 				// If you are observing a radio list then u need to get the Element js plugin value
 				var obsValue = document.id(this.options.observerid).get('value');
 				if (typeOf(obsValue) === 'null') {
 					obsValue = Fabrik.blocks[this.options.formRef].formElements.get(this.options.observerid).get('value');
 				}
 
+				Fabrik.loader.start(this.getInputElement());
+				if (this.ajax) {
+					Fabrik.loader.stop(this.getInputElement());
+					this.menuClose();
+					this.ajax.cancel();
+				}
 				this.ajax = new Request({
-					method: 'post',
 					url : this.options.url,
+					method: this.options.ajaxmethod,
 					data: {
 						value: v,
 						fabrik_cascade_ajax_update: 1,
-						v: obsValue
+						v: observer.get('value')
 					},
 
-					onSuccess: function (e) {
-						this.completeAjax(e);
+					onSuccess: function (r) {
+						Fabrik.loader.stop(this.getInputElement());
+						r = JSON.decode(r);
+						this.completeAjax(r, v);
 					}.bind(this),
 
 					onError: function (text, error) {
-						console.log(text, error);
+						fconsole(text, error);
 					},
 					onFailure: function (xhr) {
-						console.log(xhr);
+						fconsole(xhr);
 					}
 				}).send();
 			}
 		}
-		this.searchText = v;
 	}
 });


### PR DESCRIPTION
1. Improved caching when not autocomplete (multiple) words (i.e. no space in the typed string):
   
   Single result: If you get a single ajax result, then you know that any additional (correct) characters typed would also have a single result. So if you type "Clayb" and get "Rob Clayburn" returned then you know that "Claybu", "Claybur" and "Clayburn" would also return the same single result as would "Rob Claybu" etc.
   
   Multiple results: If you get multiple ajax results, then when you get an additional letter typed, you can simply search the existing result and create a new cache entry deleting those results which do not have the new string in without making a new ajax call. So if you type "Clay" and get "Rob Clayburn" and "Cassius Clay" then when you add a "b" you can deduce that the ajax result would be only "Rob Clayburn" and create and use a cache result without an ajax call.
2. Predictive text functionality - when you get a single result, you populate the field with this result but select the characters after the typed string. If the next (correct) character is typed then it replaces the selected text and (because of 1a. above) the new search string is already cached and no ajax call is needed. So, if you type "Clayb" then field is populated with "Rob Clayburn" with the "urn" selected - when you type "u", the string is now "Rob Claybu" which has been cached by 1a. so it immediately sets the field back to "Rob Clayburn" this time with "rn" selected.
3. Improved ajax error handling - ajax calls have been adjusted to use the full capabilities of the mootools Request as per mootools documentation.
4. Same code now for bootstrap / non-bootstrap using "if Fabrik.bootstrap" where logic differs.
   For review purposes, comparisons should be made with both original files following the appropriate logic.
   Once this has been proven on both bootstrap and non-bootstrap forms, php code can be adjusted always to use autocomplete.js and autocomplete-bootstrap.js can be removed.
