### PR TITLE
Fix untranslated form button values

### DIFF
--- a/administrator/components/com_fabrik/models/forms/form.xml
+++ b/administrator/components/com_fabrik/models/forms/form.xml
@@ -127,7 +127,7 @@
 
 			<field name="reset_button_label"
 				type="text"
-				default="COM_FABRIK_FIELD_RESET_BUTTON_LABEL_DEFAULT"
+				default="Reset"
 				description="COM_FABRIK_FIELD_RESET_BUTTON_LABEL_DESC"
 				label="COM_FABRIK_FIELD_RESET_BUTTON_LABEL_LABEL"/>
 
@@ -162,7 +162,7 @@
 
 			<field name="copy_button_label"
 				type="text"
-				default="COM_FABRIK_FIELD_COPY_BUTTON_LABEL_DEFAULT"
+				default="Save as Copy"
 				description="COM_FABRIK_FIELD_COPY_BUTTON_LABEL_DESC"
 				label="COM_FABRIK_FIELD_COPY_BUTTON_LABEL_LABEL"/>
 
@@ -197,7 +197,7 @@
 
 			<field name="goback_button_label"
 				type="text"
-				default="COM_FABRIK_FIELD_GO_BACK_BUTTON_LABEL_DEFAULT"
+				default="Go back"
 				description="COM_FABRIK_FIELD_GO_BACK_BUTTON_LABEL_DESC"
 				label="COM_FABRIK_FIELD_GO_BACK_BUTTON_LABEL_LABEL"/>
 
@@ -232,7 +232,7 @@
 
 			<field name="apply_button_label"
 				type="text"
-				default="COM_FABRIK_FIELD_APPLY_BUTTON_LABEL_DEFAULT"
+				default="Apply"
 				description="COM_FABRIK_FIELD_APPLY_BUTTON_LABEL_DESC"
 				label="COM_FABRIK_FIELD_APPLY_BUTTON_LABEL_LABEL"/>
 
@@ -267,7 +267,7 @@
 
 			<field name="delete_button_label"
 				type="text"
-				default="COM_FABRIK_FIELD_DELETE_BUTTON_LABEL_DEFAULT"
+				default="Delete"
 				description="COM_FABRIK_FIELD_DELETE_BUTTON_LABEL_DESC"
 				label="COM_FABRIK_FIELD_DELETE_BUTTON_LABEL_LABEL" />
 
@@ -302,7 +302,7 @@
 
 			<field name="submit_button_label"
 				type="text"
-				default="COM_FABRIK_FIELD_SUBMIT_BUTTON_LABEL_DEFAULT"
+				default="Save"
 				description="COM_FABRIK_FIELD_SUBMIT_BUTTON_LABEL_DESC"
 				label="COM_FABRIK_FIELD_SUBMIT_BUTTON_LABEL_LABEL"/>
 


### PR DESCRIPTION
I still believe that these should be put back to where they were for a better user experience for novices as they will see e.g. "COM_FABRIK_FIELD_SUBMIT_BUTTON_LABEL_DEFAULT" in the Save button text field instead of "Save".

My intent with the original change was to set the default text to "Save" translated into local language, not to put a COM_FABRIK string in there, however Joomla does not translate the default value.
