### PR TITLE
internalid wasn't autocreated when list was created on an existing table

### DIFF
--- a/administrator/components/com_fabrik/models/list.php
+++ b/administrator/components/com_fabrik/models/list.php
@@ -1244,7 +1244,8 @@ class FabrikModelList extends FabModelAdmin
 					}
 				}
 				// Then alter if defined in Fabrik global config
-				$plugin = $fbConfig->get($type, $plugin);
+				// Jaanus: but first check if there are any pk field and if yes then create as internalid
+				$plugin = ($key[0]['colname'] == $label && JString::strtolower(substr($key[0]['type'], 0, 3)) === 'int') ? 'internalid' : $fbConfig->get($type, $plugin);
 			}
 			$element->plugin = $plugin;
 			$element->hidden = $element->label == 'id' ? '1' : '0';


### PR DESCRIPTION
... and the same thing was with table joins ('field' elements on pk fields instead internalid in joined data groups)
