### PR TITLE
Also for Joomla3/F3.1 - autocreate pk element as internalid

### DIFF
--- a/administrator/components/com_fabrik/models/list.php
+++ b/administrator/components/com_fabrik/models/list.php
@@ -1277,8 +1277,8 @@ class FabrikAdminModelList extends FabModelAdmin
 					}
 				}
 				// Then alter if defined in Fabrik global config
-				$plugin = $fbConfig->get($type, $plugin);
-			}
+        			// Jaanus: but first check if there are any pk field and if yes then create as internalid
+        			$plugin = ($key[0]['colname'] == $label && JString::strtolower(substr($key[0]['type'], 0, 3)) === 'int') ? 'internalid' : $fbConfig->get($type, $plugin);			}
 
 			$element->plugin = $plugin;
 			$element->hidden = $element->label == 'id' ? '1' : '0';


### PR DESCRIPTION
This fix is already committed for F3.0, but 3.1 needs it as well. Without this the pk element was autocreated as "field" instead of "internalid" when new list was created on existing table. 
The same happened also to joined groups when new table joins were created via list admin to table without any list (and internalid element).
