### PR TITLE
related links J2.5/3.0 - whoops

### DIFF
--- a/components/com_fabrik/models/form.php
+++ b/components/com_fabrik/models/form.php
@@ -4461,7 +4461,7 @@ class FabrikFEModelForm extends FabModelForm
 						
 						// Jaanus: label after add link if no list link helps to make difference between data view links and only add links.
 						
-						$links[$element->list_id][] =  $referringTable->viewFormLink($popUpLink, $element, null, $linkKey, $val, false, null) . $label;
+						$links[$element->list_id][] =  $referringTable->viewFormLink($popUpLink, $element, null, $linkKey, $val, false, $f) . $label;
 					}
 				}
 				$f++;


### PR DESCRIPTION
Absence of $f (null instead) seems not to affect to related add, but it was originally there. Forgotten to restore it after one test with no result.
