### PR TITLE
Update template_css.php

### DIFF
--- a/components/com_fabrik/views/list/tmpl/default/template_css.php
+++ b/components/com_fabrik/views/list/tmpl/default/template_css.php
@@ -40,7 +40,7 @@ echo "
 }
 
 #listform_$c .emptyfabrikDataContainer{
-	display: none;
+/*	display: none; */
 }
 
 #listform_$c a,


### PR DESCRIPTION
The default for this should be to display an empty table. I will hide tables, where "filter required" = true. And it will not allow you to enter the filter criteria if the filter is part of the dataContainer. This would lead to support questions.
