### PR TITLE
Avoid table update INT(1) to TINYINT(1)

### DIFF
--- a/plugins/fabrik_element/yesno/yesno.php
+++ b/plugins/fabrik_element/yesno/yesno.php
@@ -29,7 +29,7 @@ class PlgFabrik_ElementYesno extends PlgFabrik_ElementRadiobutton
 	 *
 	 * @var string
 	 */
-	protected $fieldDesc = 'TINYINT(%s)';
+	protected $fieldDesc = 'INT(%s)';
 
 	/**
 	 * Db table field size


### PR DESCRIPTION
Although you can define a TINYINT field in MySQL, it is reported back as
an INT field. So whenever you save a yesno element, it askes you to
changes from INT(1) to TINYINT(1).
