### PR TITLE
Fix misaligned elements with blank labels

### DIFF
--- a/components/com_fabrik/models/element.php
+++ b/components/com_fabrik/models/element.php
@@ -1540,6 +1540,7 @@ class PlgFabrik_Element extends FabrikPlugin
 			}
 
 			$labelText = JText::_($element->label);
+			$labelText = $labelText == '' ? '&nbsp;' : $labelText;
 			$l = $j3 ? '' : $labelText;
 			$iconOpts = array('icon-class' => 'small');
 


### PR DESCRIPTION
Blank labels in Labels-Above cause element to be in label position
rather than element position.
