### PR TITLE
Fix javascript display order

### DIFF
--- a/administrator/components/com_fabrik/models/element.php
+++ b/administrator/components/com_fabrik/models/element.php
@@ -211,7 +211,7 @@ class FabrikAdminModelElement extends FabModelAdmin
 		$db = FabrikWorker::getDbo(true);
 		$query = $db->getQuery(true);
 		$id = (int) $this->getItem()->id;
-		$query->select('*')->from('#__{package}_jsactions')->where('element_id = ' . $id);
+		$query->select('*')->from('#__{package}_jsactions')->where('element_id = ' . $id)->order('id');
 		$db->setQuery($query);
 		$items = $db->loadObjectList();
 


### PR DESCRIPTION
When you save and redisplay javascript on an element, the javascript actions appear in a different order.

This fix adds an ORDER clause to the query to ensure that the records are received in the same sequence as saved.
