### PR TITLE
Fixed: Trashed tables loaded in $aTableNames

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -1260,6 +1260,7 @@ $groupBy .= '_raw';
 		$action = $app->isAdmin() ? 'task' : 'view';
 		$query = $db->getQuery(true);
 		$query->select('id, label, db_table_name')->from('#__{package}_lists');
+		$query->where('published <> -2');
 		$db->setQuery($query);
 		$aTableNames = $db->loadObjectList('label');
 		if ($db->getErrorNum())


### PR DESCRIPTION
Issue: Getting error: "getData:Unknown column '336' in 'order clause' SQL=SELECT SQL_CALC_FOUND_ROWS DISTINCT `ha_events`.`fabrik_internal_id` AS slug , `ha_events`.`fabrik_internal_id` AS `__pk_val` FROM `ha_events` ORDER BY `336` DESC LIMIT 0, 10"

Reproduce: 
- Edit a list and "accidentally" hit Save as Copy
- Discover mistake and then Trash the copied table
- Have a second table that is setup to list related data of the previous table
- View the list of the second table and the link to the related data is pointing to the ID of the Trashed Table
  ?option=com_fabrik&view=list&listid=TRASHED_TABLE&Itemid=43&Itemid=43&ha_events___source_raw=2&limitstart38=0&&resetfilters=1&&fabrik_incsessionfilters=0

Fixed: Do not load Trashed tables in $aTableNames

Better Fixes could be:
1) Do not load Unpublished tables either: $query->where('published = 1')
2) Do not find TableID of $aTableNames, the correct tableID is already know in: $linksToForms[$k]->list_id
I didn't dare to implement these, afraid of breaking something else.

Regards,
Paul
