### PR TITLE
Fixes for groups not shown in form - they should not update data and should be displayed in list

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -6513,7 +6513,7 @@ class FabrikFEModelList extends JModelForm
 			$groupHeadings[$groupHeadingKey] = 0;
 			$elementModels = $groupModel->getPublishedListElements();
 
-			if ($groupModel->canView() === false)
+			if ($groupModel->canView('list') === false)
 			{
 				continue;
 			}
@@ -7226,7 +7226,7 @@ class FabrikFEModelList extends JModelForm
 					 * If the group is un-editable - then the form won't contain the group data, thus we don't want to add blank data into $oRecord
 					 * @see http://fabrikar.com/forums/index.php?threads/changing-access-level-for-a-group-corrupts-data.34067/
 					 */
-					if (!$groupModel->canView())
+					if (!$groupModel->canView('form'))
 					{
 						continue;
 					}

--- a/components/com_fabrik/views/form/view.base.php
+++ b/components/com_fabrik/views/form/view.base.php
@@ -495,7 +495,7 @@ class FabrikViewFormBase extends JViewLegacy
 			$groupId = $groupModel->getGroup()->id;
 			$groupedJs->$groupId = array();
 
-			if (!$groupModel->canView())
+			if (!$groupModel->canView('form'))
 			{
 				continue;
 			}

--- a/components/com_fabrik/views/form/view.raw.php
+++ b/components/com_fabrik/views/form/view.raw.php
@@ -118,7 +118,7 @@ class FabrikViewForm extends JViewLegacy
 						$foreignKey = $joinTable->table_join_key;
 
 						// $$$ rob test!!!
-						if (!$groupModel->canView())
+						if (!$groupModel->canView('form'))
 						{
 							continue;
 						}


### PR DESCRIPTION
modified form.php and group.php so that if group is not shown then the form really doesn't try to update data and if shown only in details then really shown in details + in list view.

Commit a3c91c0b660f1077f06d84d88f63737c4ac24912.was initially reverted but then restored as it may be still necessary
