### PR TITLE
FIX: if root folder is set to '/' then all '/'s are stripped out of the ...

### DIFF
--- a/plugins/fabrik_element/image/image.php
+++ b/plugins/fabrik_element/image/image.php
@@ -289,7 +289,7 @@ class PlgFabrik_ElementImage extends PlgFabrik_Element
 		$value = $this->getValue($data, $repeatCounter);
 		$id = $this->getHTMLId($repeatCounter);
 		$rootFolder = $this->rootFolder($value);
-		$value = str_replace($rootFolder, '', $value);
+		if ($rootFolder!='/') $value = str_replace($rootFolder, '', $value);
 
 		// $$$ rob - 30/06/2011 can only select an image if its not a remote image
 		$canSelect = ($params->get('image_front_end_select', '0') && JString::substr($value, 0, 4) !== 'http');


### PR DESCRIPTION
Yesterdays fix to the image, broke my image path's. My root folder was set to '/' and line 292 took all '/' out of the path. 

Could have just updated my root folder, however I assume that more people have their path set to '/'. 
