### PR TITLE
Add groupid to tab header for easy hiding/showing with js

### DIFF
--- a/components/com_fabrik/views/form/tmpl/bootstrap_tabs/default.php
+++ b/components/com_fabrik/views/form/tmpl/bootstrap_tabs/default.php
@@ -63,7 +63,7 @@ echo $this->plugintop;
 		// So we should only show a tab if: it is first tab, or if it is a page break
 		if (!$model->isMultiPage() || $i == 0 || $group->splitPage) :
 			?>
-				<li <?php if ($i == 0) echo 'class="active"'?>>
+				<li <?php if ($i == 0) echo 'class="active"'?> id="tab-group<?php echo $group->id;?>">
 					<a href="#group-tab<?php echo $i;?>" data-toggle="tab">
 						<?php
 							if (!empty($group->title))


### PR DESCRIPTION
Added group id to nav-tab li elements for easy hiding/showing over js.
Now following code can be used to hide/show tab pages:
  t = document.id('tab-group52');  if (t !== null) t.style.display= 'none';
  t = document.id('tab-group52');  if (t !== null) t.style.display= 'block';
