### PR TITLE
Require window.js

### DIFF
--- a/components/com_fabrik/helpers/html.php
+++ b/components/com_fabrik/helpers/html.php
@@ -944,6 +944,7 @@ if (!$j3)
 
 				$liveSiteReq = array();
 				$liveSiteReq[] = 'media/com_fabrik/js/fabrik' . $ext;
+				$liveSiteReq[] = 'media/com_fabrik/js/window' . $ext;				
 				if ($bootstrapped)
 				{
 					$liveSiteReq[] = 'media/com_fabrik/js/tipsBootStrapMock' . $ext;


### PR DESCRIPTION
Hi Rob,

I was trying to implement myFabWin, I ran into some issues; Following the instructions from here: http://fabrikar.com/forums/index.php?wiki/javascript-window-class/

Created an article with the code as in example. No other Fabrik content on the page. 
Issue 1) Following errors on load:
"NetworkError: 404 Not Found - http://.../fab/tipsBootStrapMock.js"
tipsBo...Mock.js
"NetworkError: 404 Not Found - http://.../fab/fabrik.js"
fabrik.js

Resolve: Update documentation on the wiki to include FabrikHelperHTML::iniRequireJs(); Unless you think it is better to call this from: FabrikHelperHTML::framework();

Issue 2) Windows.js is not loaded.
TypeError: Fabrik.getWindow is not a function
Fabrik.getWindow(opts);

Resolve: Added this as required to FabrikHelperHTML::framework(). I did not completely understand this code and whether this is the right fix. I did see window.js is part of the the self::$framework array. But somehow it is not loaded. Adding it like this does seem to fix it, and I did not see any side effects.

Regards,
Paul
