### PR TITLE
FIX Ajax filter stuck

### DIFF
--- a/media/com_fabrik/js/list.js
+++ b/media/com_fabrik/js/list.js
@@ -134,10 +134,11 @@ var FbList = new Class({
 	watchAll: function (ajaxUpdate) {
 		ajaxUpdate = ajaxUpdate ? ajaxUpdate : false;
 		this.watchNav();
+		this.storeCurrentValue();
 		if (!ajaxUpdate) {
 			this.watchRows();
+			this.watchFilters();
 		}
-		this.watchFilters();
 		this.watchOrder();
 		this.watchEmpty();
 		if (!ajaxUpdate) {
@@ -553,6 +554,14 @@ var FbList = new Class({
 		return document.id(this.options.form).getElements('.fabrik_filter');
 	},
 
+	storeCurrentValue: function() {
+		this.getFilters().each(function (f) {
+			if (this.options.filterMethod !== 'submitform') {
+				f.store('initialvalue', f.get('value'));
+			}
+		}.bind(this));
+	},
+	
 	watchFilters: function () {
 		var e = '';
 		var submit = document.id(this.options.form).getElements('.fabrik_filter_submit');
@@ -560,7 +569,7 @@ var FbList = new Class({
 			e = f.get('tag') === 'select' ? 'change' : 'blur';
 			if (this.options.filterMethod !== 'submitform') {
 				f.removeEvent(e);
-				f.store('initialvalue', f.get('value'));
+//				f.store('initialvalue', f.get('value'));
 				f.addEvent(e, function (e) {
 					e.stop();
 					if (e.target.retrieve('initialvalue') !== e.target.get('value')) {


### PR DESCRIPTION
Problem: Ajax filter is stuck on ajax spinner after changing filter 2-3 filter changes. Takes 3 on initial load and 2 after refresh.

Reproduce: Setup a simple list, 1 field. And have a dropdown filter on this. Filter list onChange. Have NO submit button (fabrik_filter_submit button) on the page. Load the page, flip the filter 3 times and should be stuck. 

Solution: Problem seems to be in the rebinding filter events. I.e. it looks like the removeEvent is somehow not working. On the second filter change 2 events seem to be fired at the same time (breaking at doFilter twice, but only 1 post or _rowUpdate). By taking the watchFilter out of the Ajax refresh this work a lot better. I current value does need to be stored.
