### PR TITLE
Various validation improvements

### DIFF
--- a/media/com_fabrik/js/element.js
+++ b/media/com_fabrik/js/element.js
@@ -500,20 +500,20 @@ var FbElement =  new Class({
 							e.grab(this.successImage.clone(), 'top');
 						}
 					}.bind(this));
+					var delfn = function () {
+						var container = this.getContainer();
+						if (container.hasClass('fabrikSuccess')) {
+							errorElements.each(function (e) {
+								e.empty();
+								e.removeClass('text-success').addClass('fabrikHide');
+							});
+							container.removeClass('success').removeClass('fabrikSuccess');
+							this.removeTipMsg();
+						}
+						this.successTimer = null;
+					}.bind(this);
+					this.successTimer = window.setTimeout(delfn, 5000);
 				}
-				var delfn = function () {
-					var container = this.getContainer();
-					if (container.hasClass('fabrikSuccess')) {
-						errorElements.each(function (e) {
-							e.empty();
-							e.removeClass('text-success').addClass('fabrikHide');
-						});
-						container.removeClass('success').removeClass('fabrikSuccess');
-						this.removeTipMsg();
-					}
-					this.successTimer = null;
-				}.bind(this);
-				this.successTimer = window.setTimeout(delfn, 5000);
 				break;
 		}
 

--- a/media/com_fabrik/js/form.js
+++ b/media/com_fabrik/js/form.js
@@ -26,7 +26,6 @@ var FbForm = new Class({
 		'customJsAction': '',
 		'plugins': [],
 		'inlineMessage': true,
-		'print': false,
 		'images': {
 			'alert': '',
 			'action_check': '',
@@ -124,23 +123,8 @@ var FbForm = new Class({
 			}.bind(this));
 			this.watchGoBackButton();
 		}
-		
-		this.watchPrintButton();
 	},
 
-	/**
-	 * Print button action - either open up the print preview window - or print if already opened
-	 */
-	watchPrintButton: function () {
-		document.getElements('a[data-fabrik-print]').addEvent('click', function (e) {
-			e.stop();
-			if (this.options.print) {
-				window.print();
-			} else {
-				window.open(e.target.get('href'), 'win2', 'status=no,toolbar=no,scrollbars=yes,titlebar=no,menubar=no,resizable=yes,width=400,height=350,directories=no,location=no;');
-			}
-		}.bind(this));
-	},
 	// Go back button in ajax pop up window should close the window
 
 	watchGoBackButton: function () {
@@ -797,7 +781,7 @@ var FbForm = new Class({
 	doElementClearError: function (e, subEl) {
 		// If not doing ajax validation, then clear error messages for a field on same events
 		var id = this._getValidationElId(e, subEl);
-		this._showElementError('', id, true);
+		this.formElements.get(id).setErrorMessage('', '', true);
 		this.updateMainError();
 	},
 
@@ -934,8 +918,9 @@ var FbForm = new Class({
 		return err;
 	},
 
-	_showElementError: function (msg, id) {
+	_showElementError: function (msg, id, single) {
 		// msg should be the errors for the specific element, down to its repeat group id.
+		single = typeOf(single) !== 'null' ? single : false;
 		if (typeOf(msg) === 'array') {
 			msg = msg.flatten().join('<br />');
 		}
@@ -943,7 +928,7 @@ var FbForm = new Class({
 		if (msg === '') {
 			msg = Joomla.JText._('COM_FABRIK_SUCCESS');
 		}
-		this.formElements.get(id).setErrorMessage(msg, classname);
+		this.formElements.get(id).setErrorMessage(msg, classname, single);
 		return (classname === 'fabrikSuccess') ? false : true;
 	},
 


### PR DESCRIPTION
Mainly to address http://www.fabrikar.com/forums/index.php?threads/ajax-validation-never-ending-in-forms.36907/ but other minor issues addressed also.
1. Move element validation to element.js in order to allow multiple element validations in parallel.
2. Clean code to minimise JsHint messages.
3. Remove ajaxmethod - post is default and since post must be used (since gets indicate a prefilter), this has no point.
4. Maximise use of mootools Request events to ensure clean use of spinner.
5. Correct typos in Fabrik Events (by adding corrected name rather than replacing existing)
6. Make consistent error reporting console log format.
7. Fix validation on db-join autocomplete.
