### PR TITLE
Added .js files to install manifest

### DIFF
--- a/plugins/fabrik_element/display/display.xml
+++ b/plugins/fabrik_element/display/display.xml
@@ -13,6 +13,8 @@
 	<files>
 		<filename plugin="display">display.php</filename>
 		<filename>index.html</filename>
+		<filename>display.js</filename>
+		<filename>display-min.js</filename>
 		<folder>forms</folder>
 		<folder>language</folder>
 	</files>


### PR DESCRIPTION
After a clean install using 3.1rc2, I received a JavaScript console error (_404 plugins/fabrik_element/display/display-min.js_ Not Found). The files are there, they just weren't installed because they were not listed in the manifest XML file. This should fix it.
