### PR TITLE
Remove spurious space in List heading...

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -6608,7 +6608,7 @@ class FabrikFEModelList extends JModelForm
 						}
 					}
 
-					$heading = '<a ' . $class . ' href="#">' . $img . ' ' . $label . '</a>';
+					$heading = '<a ' . $class . ' href="#">' . $img . $label . '</a>';
 				}
 				else
 				{


### PR DESCRIPTION
... that leads to an underscored space between the icon and the label
which is unsightly.

If more whitespace is required between icon and label, it can be added
using CSS.
