### PR TITLE
Fix isuniquevalue with pk not internalid

### DIFF
--- a/plugins/fabrik_validationrule/isuniquevalue/isuniquevalue.php
+++ b/plugins/fabrik_validationrule/isuniquevalue/isuniquevalue.php
@@ -68,9 +68,16 @@ class PlgFabrik_ValidationruleIsUniqueValue extends PlgFabrik_Validationrule
 		 * @TODO - is there a better way getting the rowid?  What if this is form a joined table?
 		 * $rowid = $input->get('rowid');
 		 * Have to do it by grabbing PK from request, 'cos rowid isn't set on AJAX validation
+		 *
+		 * Paul - if pk is an input field, then input pk may not be original so should use rowid
+		 * to match the record in the DB that matches THIS record, rather than the user changed pk.
+		 * Hugh rightly points out that this does not handle joined tables correctly, but this is
+		 * true if we use:
+		 * $rowid = $input->get('rowid','');    or
+		 * $rowid = $input->get($pk,'');
+			$pk = FabrikString::safeColNameToArrayKey($table->db_primary_key);
 		 */
-		$pk = FabrikString::safeColNameToArrayKey($table->db_primary_key);
-		$rowid = $input->get($pk, '');
+		$rowid = $input->get('rowid', '');
 
 		if (!empty($rowid))
 		{
@@ -80,6 +87,6 @@ class PlgFabrik_ValidationruleIsUniqueValue extends PlgFabrik_Validationrule
 		$db->setQuery($query);
 		$c = $db->loadResult();
 
-		return ($c == 0) ? true : false;
+		return ($c === '0') ? true : false;
 	}
 }


### PR DESCRIPTION
Note: Previous version did not handle joined tables - nor does this version.
