### PR TITLE
Avoid confirmation saving internalid

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -4576,9 +4576,13 @@ class FabrikFEModelList extends JModelForm
 
 				if (FabrikString::safeColName($primaryKey) == $tableName . '.' . FabrikString::safeColName($element->name) && $table->auto_inc)
 				{
-					if (!strpos($q, ' NOT NULL AUTO_INCREMENT'))
+					if (!stripos($q, ' NOT NULL'))
 					{
-						$q .= ' NOT NULL AUTO_INCREMENT ';
+						$q .= ' NOT NULL';
+					}
+					if (!stripos($q, ' AUTO_INCREMENT'))
+					{
+						$q .= ' AUTO_INCREMENT';
 					}
 				}
 


### PR DESCRIPTION
Avoid confirmation "Update from INT(11) to INT(11) AUTO_INCREMENT" when saving internalid field.
