### PR TITLE
Fix missing requirejs for list-element.js.

### DIFF
--- a/components/com_fabrik/models/element.php
+++ b/components/com_fabrik/models/element.php
@@ -5406,8 +5406,7 @@ class PlgFabrik_Element extends FabrikPlugin
 	{
 		$p = $this->getElement()->plugin;
 		$src = 'plugins/fabrik_element/' . $p . '/list-' . $p . '.js';
-
-		if (JFile::exists($src))
+		if (JFile::exists(JPATH_SITE . '/' . $src))
 		{
 			$srcs[] = $src;
 		}


### PR DESCRIPTION
Fix a JS error resulting from list-calc.js not being included in requirejs list for where FbCalcList is called.
