### PR TITLE
Fix: strings without quotes in dbjoin where clause

### DIFF
--- a/plugins/fabrik_element/databasejoin/databasejoin.php
+++ b/plugins/fabrik_element/databasejoin/databasejoin.php
@@ -3057,9 +3057,11 @@ class PlgFabrik_ElementDatabasejoin extends PlgFabrik_ElementList
 			 * IN (), if it worked, would produce no rows, just replace with 1=-1
 			 * Can't just count($v), as sometimes it's an array with a single null entry.
 			 */
-			array_map(array($db, 'quote'), $v);
-			$ins = implode(',', $v);
-
+			for ($i=0;$i<count($v);$i++)
+        		{
+        			$v[$i] = $db->quote($v[$i]);
+        		}
+        		$ins = implode(',', $v);
 			if (trim($ins) === '')
 			{
 				$query->where('1=-1');


### PR DESCRIPTION
During data submission "Unknow column 'A' .... WHERE tablename.element IN (A)" error occurred when the dbjoin element pointed to a value field that is not an integer. 
See https://github.com/Fabrik/fabrik/issues/1082
