### PR TITLE
calc fix: "array_key_exists...null given" warning

### DIFF
--- a/plugins/fabrik_element/calc/calc.php
+++ b/plugins/fabrik_element/calc/calc.php
@@ -131,8 +131,8 @@ class PlgFabrik_ElementCalc extends PlgFabrik_Element
 
 		if ($groupModel->isJoin())
 		{
-		$data = !data ? array() : $data;
-		$data[$name] = !$data[$name] ? array() : $data[$name];
+			$data = (array) $data;
+			$data[$name] = (array) $data[$name];
 
 			if ($groupModel->canRepeat())
 			{


### PR DESCRIPTION
When there are some calc element in joined group that is not shown then php warning was produced in details and edit form (not in new):

Warning: array_key_exists() expects parameter 2 to be array, null given in /.../fabrik_element/calc/calc.php on line 136

Warning: array_key_exists() expects parameter 2 to be array, null given in.../fabrik_element/calc/calc.php on line 142
