### PR TITLE
FIX: Restore zoom level when "Use Cookies" enabled

### DIFF
--- a/plugins/fabrik_visualization/googlemap/googlemap.js
+++ b/plugins/fabrik_visualization/googlemap/googlemap.js
@@ -209,7 +209,8 @@ var FbGoogleMapViz = new Class({
 			var mymaplng = Cookie.read("mymaplng_" + this.options.id);
 
 			if (mymaplat && mymaplat !== '0' && mymapzoom !== '0') {
-				this.map.setCenter(new google.maps.LatLng(mymaplat.toFloat(), mymaplng.toFloat()), mymapzoom.toInt());
+				this.map.setCenter(new google.maps.LatLng(mymaplat.toFloat(), mymaplng.toFloat()));
+				this.map.setZoom(mymapzoom.toInt());
 			} else {
 				this.center();
 			}


### PR DESCRIPTION
Saved zoom level wasn't being restored along with lat/lon when browsing back to a Maps Visualization.
