### PR TITLE
J33: add clear eval to canEdit/DeleteRow

### DIFF
--- a/plugins/fabrik_list/candeleterow/candeleterow.php
+++ b/plugins/fabrik_list/candeleterow/candeleterow.php
@@ -79,6 +79,7 @@ class PlgFabrik_ListCandeleterow extends PlgFabrik_List
 			$w = new FabrikWorker;
 			$data = JArrayHelper::fromObject($data);
 			$candeleterow_eval = $w->parseMessageForPlaceHolder($candeleterow_eval, $data);
+			FabrikWorker::clearEval();
 			$candeleterow_eval = @eval($candeleterow_eval);
 			FabrikWorker::logEval($candeleterow_eval, 'Caught exception on eval in can delete row : %s');
 

--- a/plugins/fabrik_list/caneditrow/caneditrow.php
+++ b/plugins/fabrik_list/caneditrow/caneditrow.php
@@ -91,6 +91,7 @@ class PlgFabrik_ListCaneditrow extends PlgFabrik_List
 			$w = new FabrikWorker;
 			$data = JArrayHelper::fromObject($data);
 			$caneditrow_eval = $w->parseMessageForPlaceHolder($caneditrow_eval, $data);
+			FabrikWorker::clearEval();
 			$caneditrow_eval = @eval($caneditrow_eval);
 			FabrikWorker::logEval($caneditrow_eval, 'Caught exception on eval in can edit row : %s');
 			$this->acl[$data['__pk_val']] = $caneditrow_eval;


### PR DESCRIPTION
So it won't throw an error if the eval'ed result is FALSE
