### PR TITLE
"unable to find this record" issue: possible fix

### DIFF
--- a/components/com_fabrik/models/form.php
+++ b/components/com_fabrik/models/form.php
@@ -3217,7 +3217,7 @@ class FabrikFEModelForm extends FabModelForm
 							else
 							{
 								// If no key found set rowid to 0 so we can insert a new record.
-								if (empty($usekey) && !$this->isMambot)
+								if (empty($usekey) && !$this->isMambot && in_array($input->get('view'), array('form', 'details')))
 								{
 									$this->rowId = '';
 									/**


### PR DESCRIPTION
A false alert was generated when form/details had some list views to display using content plugin code and the list (s) had some view/access restrictions set in prefilters and access settings. 
Additional condition in if statement ensures that the error msg would apply only to the current form or details view.
The issue was also described here:
http://fabrikar.com/forums/index.php?threads/false-alert-we-are-unable-to-find-this-record-in-details-view.38862/
