### PR TITLE
Fix yesno yes icon

### DIFF
--- a/plugins/fabrik_element/yesno/yesno.php
+++ b/plugins/fabrik_element/yesno/yesno.php
@@ -79,7 +79,6 @@ class PlgFabrik_ElementYesno extends PlgFabrik_ElementRadiobutton
 		{
 			$icon = $j3 ? 'checkmark.png' : '1.png';
 			$opts = array('alt' => FText::_('JYES'));
-			$opts['icon-class'] = 'icon-ok-sign';
 
 			return FabrikHelperHTML::image($icon, 'list', @$this->tmpl, $opts);
 		}


### PR DESCRIPTION
"No" icon is a cross.

"Yes" icon should be a tick (check-mark) but because of this line of code it appears as a white tick in a black circle.
