### PR TITLE
list order by is breaking if order by is "unset"

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -2800,12 +2800,12 @@ class FabrikFEModelList extends JModelForm
 					$dir = JArrayHelper::getValue($orderdirs, $o, 'desc');
 
 					// as we use getString() for query string, need to sanitize
-					if (!in_array(strtolower($dir), array('asc', 'desc')))
+					if (!in_array(strtolower($dir), array('asc', 'desc','-')))
 					{
 						throw new ErrorException('invalid order direction: ' . $dir, 500);
 					}
 
-					if ($orderbyRaw !== '')
+					if ($orderbyRaw !== '' && $dir != '-')
 					{
 						// $$$ hugh - getOrderByName can return a CONCAT, ie join element ...
 


### PR DESCRIPTION
This is fixing the issue in case of non-ajaxfied list.
Not sure if it will cover all cases.

$dir = '-'; (set in list.js)
but $orderbyRaw still contains the last orderby element name (so if the sanitizing is skipped for '-' it's doing a " ...order by element - " and so breaking again.

See https://github.com/Fabrik/fabrik/issues/1288
