### PR TITLE
List template is ignored when using Joomla 2.5

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -11032,8 +11032,16 @@ class FabrikFEModelList extends JModelForm
 			}
 
 			// Migration test
-			$modFolder = JPATH_SITE . '/templates/' . $app->getTemplate() . '/html/com_fabrik/list/' . $this->tmpl;
-			$componentFolder = JPATH_SITE . '/components/com_fabrik/views/list/tmpl/' . $this->tmpl;
+			if (FabrikWorker::j3())
+			{
+				$modFolder = JPATH_SITE . '/templates/' . $app->getTemplate() . '/html/com_fabrik/list/' . $this->tmpl;
+				$componentFolder = JPATH_SITE . '/components/com_fabrik/views/list/tmpl/' . $this->tmpl;
+			}
+			else
+			{
+				$modFolder = JPATH_SITE . '/templates/' . $app->getTemplate() . '/themes/' . $this->tmpl;
+				$componentFolder = JPATH_SITE . '/components/com_fabrik/views/list/tmpl25/' . $this->tmpl;
+			}
 
 			if (!JFolder::exists($componentFolder) && !JFolder::exists($modFolder))
 			{


### PR DESCRIPTION
When running with Joomla 2.5 the list template was always ignored because the wrong template directory was searched.

Directory components/com_fabrik/views/list/tmpl25 is used for Joomla 2.5 templates.
