### PR TITLE
changed line #298 for fixing an issue when saving static google maps

### DIFF
--- a/components/com_fabrik/helpers/image.php
+++ b/components/com_fabrik/helpers/image.php
@@ -295,7 +295,7 @@ class Fabimage
 		else
 		{
 			// No cached image, grab image from remote URI and store locally
-			file_put_contents($cacheFile, file_get_contents($src));
+			$file=uniqid('map_');$cacheFile = $folder . $file;file_put_contents($cacheFile, file_get_contents($src));
 		}
 
 		$src = COM_FABRIK_LIVESITE . $path . $file;


### PR DESCRIPTION
I only changed line #298 in file \components\com_fabrik\helpers\image.php

from
file_put_contents($cacheFile, file_get_contents($src));
to
$file=uniqid('map_');$cacheFile = $folder . $file;file_put_contents($cacheFile, file_get_contents($src));

But all the file content has been marked has changed. 
Don't know how to avoid that
