### PR TITLE
Ajax file upload failing when SEF url

### DIFF
--- a/plugins/fabrik_element/fileupload/fileupload.js
+++ b/plugins/fabrik_element/fileupload/fileupload.js
@@ -287,7 +287,8 @@ var FbFileUpload = new Class({
 			chunk_size: this.options.ajax_chunk_size + 'kb',
 			dragdrop : true,
 			multipart: true,
-			filters: this.options.filters
+			filters: this.options.filters,
+			page_url: this.options.page_url
 		};
 		this.uploader = new plupload.Uploader(plupopts);
 

--- a/plugins/fabrik_element/fileupload/fileupload.php
+++ b/plugins/fabrik_element/fileupload/fileupload.php
@@ -431,6 +431,7 @@ class PlgFabrik_ElementFileupload extends PlgFabrik_Element
 		$opts->elementShortName = $element->name;
 		$opts->listName = $this->getListModel()->getTable()->db_table_name;
 		$opts->useWIP = (bool) $params->get('upload_use_wip', '0') == '1';
+		$opts->page_url = COM_FABRIK_LIVESITE;
 		
 		JText::script('PLG_ELEMENT_FILEUPLOAD_MAX_UPLOAD_REACHED');
 		JText::script('PLG_ELEMENT_FILEUPLOAD_DRAG_FILES_HERE');


### PR DESCRIPTION
We are adding page_url as its needed as reference in cases with SEF url where the plupload library would otherwise use document.location as url. Refer to plupload::init function for more.

According to the following discussion there seem to be issue when in SSL mode too, but the init code doesn't substantiate such case.

http://fabrikar.com/forums/index.php?threads/http-error-in-file-upload-with-ajax.40306/