### PR TITLE
Fix:empty BD always saved 0000-00-00, making NULL as default

### DIFF
--- a/plugins/fabrik_element/birthday/birthday.php
+++ b/plugins/fabrik_element/birthday/birthday.php
@@ -321,14 +321,17 @@ class PlgFabrik_ElementBirthday extends PlgFabrik_Element
 
 		if (is_array($val))
 		{
-			if ($params->get('empty_is_null', '0') == 0 || !in_array('', $val))
+			if ($params->get('empty_is_null', '1') == 0 || !in_array('', $val))
 			{
 				return $val[2] . '-' . $val[1] . '-' . $val[0];
 			}
 		}
 		else
 		{
-			return $val;
+			if ($params->get('empty_is_null', '1') == '0' || !in_array('', explode('-',$val)))
+			{
+				return $val;
+			}
 		}
 	}
 

--- a/plugins/fabrik_element/birthday/forms/fields.xml
+++ b/plugins/fabrik_element/birthday/forms/fields.xml
@@ -119,7 +119,7 @@
 
 			<field name="empty_is_null"
 				type="radio"
-				default="0"
+				default="1"
 				class="btn-group"
 				label="PLG_ELEMENT_BIRTHDAY_EMPTYISNULL"
 				description="PLG_ELEMENT_BIRTHDAY_EMPTYISNULLDESC">


### PR DESCRIPTION
Redoing this PR https://github.com/Fabrik/fabrik/pull/1176 
because it contained stuff not belonging here. 
BD element lost once its ability to save empty data as NULL. Along this fix let's set NULL as default empty value.