### PR TITLE
Dotted letters and spaces were stripped from popup form

### DIFF
--- a/components/com_fabrik/models/form.php
+++ b/components/com_fabrik/models/form.php
@@ -1604,7 +1604,7 @@ class FabrikFEModelForm extends FabModelForm
 			if ($this->dofilter)
 			{
 				//$item = preg_replace('/%([0-9A-F]{2})/mei', "chr(hexdec('\\1'))", $item);
-				$item = preg_replace_callback('/%([0-9A-F]{2})/mi',  function($m){return utf8_encode(chr(hexdec('\\1')));}, $item);
+				$item = preg_replace_callback('/%([0-9A-F]{2})/mi',  "chr(hexdec('\\1'))", $item);
 				if ($this->ajaxPost)
 				{
 					$item = rawurldecode($item);


### PR DESCRIPTION
function($m){return utf8_encode() caused issue https://github.com/Fabrik/fabrik/issues/1363 with popup forms
TODO - something does the same with form labels when we copy lists