### PR TITLE
Fix for label of copied form (thanks trob!)

### DIFF
--- a/components/com_fabrik/models/form.php
+++ b/components/com_fabrik/models/form.php
@@ -4217,7 +4217,7 @@ echo "form get errors";
 		// $$$ rob newFormLabel set in table copy
 		if ($input->get('newFormLabel', '') !== '')
 		{
-			$form->label = $input->get('newFormLabel');
+			$form->label = $input->get('newFormLabel', '', '', 'string');
 		}
 
 		$res = $form->store();


### PR DESCRIPTION
When copying list all special chars and spaces were removed