### PR TITLE
Notes element removed all spaces and special chars

### DIFF
--- a/plugins/fabrik_element/notes/notes.php
+++ b/plugins/fabrik_element/notes/notes.php
@@ -387,7 +387,7 @@ class PlgFabrik_ElementNotes extends PlgFabrik_ElementDatabasejoin
 		$table = $db->quoteName($params->get('join_db_name'));
 		$col = $params->get('join_val_column');
 		$key = $db->quoteName($params->get('join_key_column'));
-		$v = $db->quote($input->get('v'));
+		$v = $db->quote($input->get('v', '', '', 'string'));
 		$rowid = $this->getFormModel()->getRowId();
 
 		// Jaanus - avoid inserting data when the form is 'new' not submitted ($rowid == '')


### PR DESCRIPTION
The same way as we used to fix the same issue with form labels, see
https://github.com/Fabrik/fabrik/commit/f4d269374ca367fd897e4c84f7dbf1808ad3d953

(doesn't fix all issues with notes, just this one)