### PR TITLE
Additional fix to allow html in radiobutton labels

### DIFF
--- a/plugins/fabrik_element/databasejoin/databasejoin.php
+++ b/plugins/fabrik_element/databasejoin/databasejoin.php
@@ -704,7 +704,10 @@ class PlgFabrik_ElementDatabasejoin extends PlgFabrik_ElementList
 		{
 			// For values like '1"'
 			// $$$ hugh - added second two params so we set double_encode false
-			$o->text = htmlspecialchars($o->text, ENT_NOQUOTES, 'UTF-8', false);
+			if ($this->getDisplayType() != 'radio') 
+			{
+				$o->text = htmlspecialchars($o->text, ENT_NOQUOTES, 'UTF-8', false);
+      			}
 		}
 
 		$table = $this->getlistModel()->getTable()->db_table_name;


### PR DESCRIPTION
< and > were html'ed to `&lt; and &gt;`
See also previous commit
https://github.com/Fabrik/fabrik/commit/847b446dc1b9789686575ce228ce1ec903375ee5