### PR TITLE
fix for "Unexpected token W" issue

### DIFF
--- a/components/com_fabrik/models/group.php
+++ b/components/com_fabrik/models/group.php
@@ -1464,7 +1464,11 @@ class FabrikFEModelGroup extends FabModel
 		 * Find out which keys were origionally in the form, but were not submitted
 		 * i.e. those keys whose records were removed
 		 */
-		$keysToDelete = array_diff($origGroupRowsIds, $usedKeys);
+		
+		if (!$formModel->isNewRecord())
+		{
+      			$keysToDelete = array_diff($origGroupRowsIds, $usedKeys);
+		}
 
 		// Nothing to delete - return
 		if (empty($keysToDelete))


### PR DESCRIPTION
when submitting form inside another content (form is displayed with content plugin) and the form contains a repeat group. 
Probably fixes also the same issue with forms in popup window.