### PR TITLE
New attending plugin never got discovered and its table wasn't created

### DIFF
--- a/plugins/fabrik_element/attending/attending.xml
+++ b/plugins/fabrik_element/attending/attending.xml
@@ -24,7 +24,7 @@
 	</uninstall>
 
 	<files>
-		<filename plugin="rating">attending.php</filename>
+		<filename plugin="attending">attending.php</filename>
 		<filename>index.html</filename>
 		<filename>attending.js</filename>
 		<filename>attending-min.js</filename>

--- a/plugins/fabrik_element/attending/sql/install.mysql.uft8.sql
+++ b/plugins/fabrik_element/attending/sql/install.mysql.uft8.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS  `#__fabrik_attending` (
 	`row_id` INT( 6 ) NOT NULL ,
 	`element_id` int ( 6 ) NOT NULL,
 	`type` VARCHAR( 255 ) NOT NULL,
-	`data` TEXT NO NULL,
-	`date_created` DATETIME NOT NULL
+	`data` TEXT NOT NULL,
+	`date_created` DATETIME NOT NULL,
 	 PRIMARY KEY ( `user_id` , `list_id` , `form_id` , `row_id`, `element_id` )
 );


### PR DESCRIPTION
Wrong plugin name in xml file made the plugin invisible for Discover and 
also CREATE TABLE #__fabrik_attending query was incorrect