### PR TITLE
Fix admin elements group sort field

### DIFF
--- a/administrator/components/com_fabrik/views/elements/tmpl/bootstrap.php
+++ b/administrator/components/com_fabrik/views/elements/tmpl/bootstrap.php
@@ -103,7 +103,7 @@ $states	= array(
 					<?php echo FText::_('COM_FABRIK_VALIDATIONS'); ?>
 				</th>
 				<th width="10%">
-				<?php echo JHTML::_('grid.sort', 'COM_FABRIK_GROUP', 'g.label', $listDirn, $listOrder); ?>
+				<?php echo JHTML::_('grid.sort', 'COM_FABRIK_GROUP', 'g.name', $listDirn, $listOrder); ?>
 				</th>
 				<th width="10%">
 					<?php echo JHTML::_('grid.sort', 'COM_FABRIK_PLUGIN', 'e.plugin', $listDirn, $listOrder); ?>


### PR DESCRIPTION
Admin elements sort by group should sort by the group name (which is what is displayed) and not the group label (which could be different).