### PR TITLE
Remove span for bootstrap if no action buttons exist

### DIFF
--- a/components/com_fabrik/views/form/tmpl/bootstrap/default_actions.php
+++ b/components/com_fabrik/views/form/tmpl/bootstrap/default_actions.php
@@ -19,13 +19,11 @@ if ($this->hasActions) : ?>
 		<?php if ( $form->submitButton || $form->applyButton || $form->copyButton ): ?>
 			<div class="span4">
 				<div class="btn-group">
-		<?php endif; ?>
 					<?php
 					echo $form->submitButton . ' ';
 					echo $form->applyButton . ' ';
 					echo $form->copyButton;
 					?>
-		<?php if ( $form->submitButton || $form->applyButton || $form->copyButton ): ?>
 				</div>
 			</div>
 		<?php endif; ?>

--- a/components/com_fabrik/views/form/tmpl/bootstrap/default_actions.php
+++ b/components/com_fabrik/views/form/tmpl/bootstrap/default_actions.php
@@ -25,7 +25,7 @@ if ($this->hasActions) : ?>
 					echo $form->applyButton . ' ';
 					echo $form->copyButton;
 					?>
-		<?php if ( $form->submitButton || $form->applyButton || echo $form->copyButton ): ?>
+		<?php if ( $form->submitButton || $form->applyButton || $form->copyButton ): ?>
 				</div>
 			</div>
 		<?php endif; ?>

--- a/components/com_fabrik/views/form/tmpl/bootstrap/default_actions.php
+++ b/components/com_fabrik/views/form/tmpl/bootstrap/default_actions.php
@@ -16,32 +16,37 @@ $form = $this->form;
 if ($this->hasActions) : ?>
 <div class="fabrikActions form-actions">
 	<div class="row-fluid">
-		<div class="span4">
-			<div class="btn-group">
-			<?php
-			echo $form->submitButton . ' ';
-			echo $form->applyButton . ' ';
-			echo $form->copyButton;
-			?>
+		<?php if ( $form->submitButton || $form->applyButton || $form->copyButton ): ?>
+			<div class="span4">
+				<div class="btn-group">
+		<?php endif; ?>
+					<?php
+					echo $form->submitButton . ' ';
+					echo $form->applyButton . ' ';
+					echo $form->copyButton;
+					?>
+		<?php if ( $form->submitButton || $form->applyButton || echo $form->copyButton ): ?>
+				</div>
 			</div>
-		</div>
-		<div class="span1"></div>
-		<div class="span2">
-			<div class="btn-group">
-				<?php echo $form->prevButton . ' ' . $form->nextButton; ?>
+		<?php endif; ?>
+		<?php if ( $form->prevButton || $form->nextButton ): ?>
+			<div class="offset1 span2">
+				<div class="btn-group">
+					<?php echo $form->prevButton . ' ' . $form->nextButton; ?>
+				</div>
 			</div>
-		</div>
-		<div class="span1"></div>
-
-		<div class="span4">
-			<div class="pull-right btn-group">
-				<?php
-				echo $form->gobackButton  . ' ' . $this->message;
-				echo $form->resetButton . ' ';
-				echo  $form->deleteButton;
-				?>
+		<?php endif; ?>
+		<?php if ( $form->gobackButton || $form->resetButton || $form->deleteButton ): ?>
+			<div class="offset1 span4">
+				<div class="pull-right btn-group">
+					<?php
+					echo $form->gobackButton  . ' ' . $this->message;
+					echo $form->resetButton . ' ';
+					echo $form->deleteButton;
+					?>
+				</div>
 			</div>
-		</div>
+		<?php endif; ?>
 	</div>
 </div>
 <?php


### PR DESCRIPTION
Remove span if no action buttons exist.
Use php to show span only if necessary, simplify the styling: for example if you have only the submit button, i cannot center it in the form container.
Then i propose to use offset class to add spaces: using an empty span1 is not so elegant.