### PR TITLE
No forced search for itemid in related data links

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -2082,6 +2082,9 @@ class FabrikFEModelList extends JModelForm
 		{
 			$bits[] = 'view=list';
 			$bits[] = 'listid=' . $listid;
+			
+			// Jaanus 12 Apr 2015 - commenting out the Itemid stuff as it totally messed up things i.e when one list was under many menu items and prefiltered differently under each item
+			/*
 			$listLinks = $this->getTableLinks();
 
 			// $$$ rob 01/03/2011 find at matching itemid in another menu item for the related data link
@@ -2094,6 +2097,7 @@ class FabrikFEModelList extends JModelForm
 					break;
 				}
 			}
+			*/
 
 			$bits[] = 'Itemid=' . $Itemid;
 		}


### PR DESCRIPTION
This totally messed up things with data displaying, templates etc when one list was displayed under many menu items being also prefiltered differently under each of them.