### PR TITLE
errror triggered when list first loads

### DIFF
--- a/components/com_fabrik/views/list/tmpl/bootstrap/default_row.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap/default_row.php
@@ -17,7 +17,7 @@ defined('_JEXEC') or die('Restricted access');
 		$style = empty($this->cellClass[$heading]['style']) ? '' : 'style="'.$this->cellClass[$heading]['style'].'"';
 		?>
 		<td class="<?php echo $this->cellClass[$heading]['class']?>" <?php echo $style?>>
-			<?php echo isset($this->_row->data)?$this->_row->data->$heading:'';?>
+			<?php echo isset($this->_row->data) ? $this->_row->data->$heading : '';?>
 		</td>
 	<?php }?>
 </tr>

--- a/components/com_fabrik/views/list/tmpl/bootstrap/default_row.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap/default_row.php
@@ -17,7 +17,7 @@ defined('_JEXEC') or die('Restricted access');
 		$style = empty($this->cellClass[$heading]['style']) ? '' : 'style="'.$this->cellClass[$heading]['style'].'"';
 		?>
 		<td class="<?php echo $this->cellClass[$heading]['class']?>" <?php echo $style?>>
-			<?php echo @$this->_row->data->$heading;?>
+			<?php echo isset($this->_row->data)?$this->_row->data->$heading:'';?>
 		</td>
 	<?php }?>
 </tr>


### PR DESCRIPTION
eliminates this persistent warning in php error_log: 'Undefined property: stdClass::$data' at /home/public_html/components/com_fabrik/views/list/tmpl/bootstrap/default_row.php 20