### PR TITLE
Update list-toggle.js

### DIFF
--- a/media/com_fabrik/js/list-toggle.js
+++ b/media/com_fabrik/js/list-toggle.js
@@ -54,10 +54,12 @@ var FbListToggle = new Class({
 
 		if (state === 'open') {
 			document.getElements('.fabrik___heading .' + col).show();
+			document.getElements('.fabrikFilterContainer .' + col).show();
 			document.getElements('.fabrik_row  .' + col).show();
 			muted = '';
 		} else {
 			document.getElements('.fabrik___heading .' + col).hide();
+			document.getElements('.fabrikFilterContainer .' + col).hide();
 			document.getElements('.fabrik_row  .' + col).hide();
 			muted = ' muted';
 		}


### PR DESCRIPTION
If both filters in header and column toggle feature is used at the same time - the fabrikFilterContainer column was not hiding/showing the toggled columns - so the headers were out of synch.