### PR TITLE
Fix for "undefined index" notice

### DIFF
--- a/plugins/fabrik_element/calc/calc.php
+++ b/plugins/fabrik_element/calc/calc.php
@@ -133,7 +133,11 @@ class PlgFabrik_ElementCalc extends PlgFabrik_Element
 		if ($groupModel->isJoin())
 		{
 			$data = (array) $data;
-			$data[$name] = (array) $data[$name];
+			
+			if (array_key_exists($name, $data))
+			{
+				$data[$name] = (array) $data[$name];
+			}
 
 			if ($groupModel->canRepeat())
 			{


### PR DESCRIPTION
appeared in form view with calc elements in joined groups when new and error reporting set to maximum