### PR TITLE
cache-error-with-filtered-list-and-back-button

### DIFF
--- a/components/com_fabrik/helpers/parent.php
+++ b/components/com_fabrik/helpers/parent.php
@@ -1745,7 +1745,8 @@ class FabrikWorker
 		}
 		else
 		{
-			$gobackaction = 'onclick=\'history.back();\'';
+			//$gobackaction = 'onclick=\'history.back();\'';
+			$gobackaction = 'onclick="parent.location=\'' . FArrayHelper::getValue($_SERVER, 'HTTP_REFERER') . '\'"';
 		}
 
 		return $gobackaction;


### PR DESCRIPTION
history.back is breaking the Back button in form if the list is filtered and not ajaxfied.
I think it's not a Fabrik issue (same effect if going back in e.g. filtered Joomla article lists) and it doesn't fix the issue if the browser back it used.
But at least the Fabrik form Back button is working again.
It's re-doing this commit https://github.com/Fabrik/fabrik/commit/080c6d65ca96366e0ead33fcbc112ac39135e482
I don't know the reason for this commit, in a discussion somebody mentioned multipage forms...

http://www.fabrikar.com/forums/index.php?threads/cache-error-with-filtered-list-and-back-button.38109/#post-208688