### PR TITLE
Bug in autocomplete in databasejoin plugin - fabrik 3x - Fixing autoc…

### DIFF
--- a/components/com_fabrik/models/elementlist.php
+++ b/components/com_fabrik/models/elementlist.php
@@ -557,7 +557,7 @@ class ElementList extends Element
 		// Search for every word separately in the result rather than the single string (of multiple words)
 		$regex  = "/(?=.*" .
 			implode(")(?=.*",
-				array_filter(explode(" ", addslashes($v)))
+				array_filter(explode(" ", preg_quote($v, '/')))
 			) . ").*/i";
 		$start = count($rows) - 1;
 


### PR DESCRIPTION
…omplete regular expression, needed to be preg_quote()'ed, not addslashes()'ed.

See commit on 3.x branch, https://github.com/Fabrik/fabrik/commit/176c5d239b91c37126ae63615a6f3d7a282d08c0 and forum discussion http://fabrikar.com/forums/index.php?threads/bug-in-autocomplete-in-databasejoin-plugin-fabrik-3-3-2.41608/