### PR TITLE
Allow calling fireEvent() on an element without event object

### DIFF
--- a/plugins/fabrik_element/button/button.js
+++ b/plugins/fabrik_element/button/button.js
@@ -14,9 +14,10 @@ var FbButton = new Class({
 
 	addNewEventAux: function (action, js) {
 		this.element.addEvent(action, function (e) {
-			
 			// Unlike element addNewEventAux we need to stop the event otherwise the form is submitted
-			e.stop();
+			if (e && e.stop) {
+				e.stop();
+			}
 			typeOf(js) === 'function' ? js.delay(0, this, this) : eval(js);
 		}.bind(this));
 	}

--- a/plugins/fabrik_element/databasejoin/databasejoin.js
+++ b/plugins/fabrik_element/databasejoin/databasejoin.js
@@ -813,7 +813,9 @@ var FbDatabasejoin = new Class({
 		default:
 			if (this.element) {
 				this.element.addEvent(action, function (e) {
-					e.stop();
+					if (e && e.stop) {
+						e.stop();
+					}
 					(typeOf(js) === 'function') ? js.delay(0, this, this) : eval(js);
 				}.bind(this));
 			}
@@ -832,13 +834,17 @@ var FbDatabasejoin = new Class({
 			var f = this.getAutoCompleteLabelField();
 			if (typeOf(f) !== 'null') {
 				f.addEvent(action, function (e) {
-					e.stop();
+					if (e && e.stop) {
+						e.stop();
+					}
 					(typeOf(js) === 'function') ? js.delay(700, this, this) : eval(js);
 				}.bind(this));
 			}
 			if (this.element) {
 				this.element.addEvent(action, function (e) {
-					e.stop();
+					if (e && e.stop) {
+						e.stop();
+					}
 					(typeOf(js) === 'function') ? js.delay(0, this, this) : eval(js);
 				}.bind(this));
 			}


### PR DESCRIPTION
Some event callbacks require an event object to function. When calling
fireEvent() directly from JS (when writing JS for a fabrik element for
example) there's no event object available, so relax the callbacks to accept
a missing event object to make it easier for the user.

An alternative is to have the user pass in an event object to all fireEvent()
calls, like this:

`$('object_name').fireEvent('change', {stop: function(){}})`
or
`$('object_name').fireEvent('change', new Event.Mock);`

But that's more complex than necessary and easy for a user to forget.

The missing event object was what caused the problem reported here:
http://fabrikar.com/forums/index.php?threads/js-error-in-databasejoin-js-onchange-js-code-not-run.38718/

.. and to me this problem was a difficult problem to debug so if we can make it
easier for other fabrik users I think that would be great! :-)

What do you think?