### PR TITLE
Show tip in details default to "no"

### DIFF
--- a/administrator/components/com_fabrik/models/forms/element.xml
+++ b/administrator/components/com_fabrik/models/forms/element.xml
@@ -605,7 +605,7 @@
 				<field name="labelindetails"
 					type="radio"
 					class="btn-group"
-					default="1"
+					default="0"
 					description="COM_FABRIK_FIELD_TIPS_IN_DETAILED_VIEW_DESC"
 					label="COM_FABRIK_FIELD_TIPS_IN_DETAILED_VIEW_LABEL">
 						<option value="0">JNO</option>


### PR DESCRIPTION
Usually the tips are not needed in details view as their main purpose is to instruct users who are filling forms.