### PR TITLE
Don't make thumbnails if it's not an image

### DIFF
--- a/plugins/fabrik_element/fileupload/fileupload.php
+++ b/plugins/fabrik_element/fileupload/fileupload.php
@@ -1863,6 +1863,12 @@ class PlgFabrik_ElementFileupload extends PlgFabrik_Element
 			$make_thumbnail = false;
 		}
 
+		// $$$ trob - oImage->rezise is only set if isImageExtension
+		if (!FabrikWorker::isImageExtension($filePath))
+		{
+			$make_thumbnail = false;
+		}
+
 		if ($make_thumbnail)
 		{
 			$thumbPath = $storage->clean(JPATH_SITE . '/' . $params->get('thumb_dir') . '/' . $myFileDir . '/', false);


### PR DESCRIPTION
http://fabrikar.com/forums/index.php?threads/problem-plugin-fileupload.42119/#post-212936

oImage is only set if isImageExtension, so thumb can only be created (oImage->resize) for images

Not sure what should happen if param(fu_make_pdf_thumb) would be true.