### PR TITLE
public function layoutGroupHeading missing in view.pdf.php

### DIFF
--- a/components/com_fabrik/views/list/view.pdf.php
+++ b/components/com_fabrik/views/list/view.pdf.php
@@ -83,4 +83,31 @@ class FabrikViewList extends FabrikViewListBase
 		// Set the download file name based on the document title
 		$this->doc->setName($this->doc->getTitle());
 	}
+		/**
+	 * Render the group by heading as a JLayout list.fabrik-group-by-heading
+
+	 *
+	 * @param   string  $groupedBy  Group by key for $this->grouptemplates
+	 * @param   array   $group      Group data
+
+
+
+	 *
+	 * @return string
+	 */
+	public function layoutGroupHeading($groupedBy, $group)
+
+	{
+		$displayData = new stdClass;
+		$displayData->emptyDataMessage = $this->emptyDataMessage;
+		$displayData->tmpl = $this->tmpl;
+		$displayData->title = $this->grouptemplates[$groupedBy];
+		$displayData->count = count($group);
+		$layout = FabrikHelperHTML::getLayout('list.fabrik-group-by-heading');
+
+
+		return $layout->render($displayData);
+
+
+	}
 }


### PR DESCRIPTION
Is this the correct place to do it? (I just copied the function from view.html.php)

http://fabrikar.com/forums/index.php?threads/group-by-not-working-in-list-view.42581/
http://fabrikar.com/forums/index.php?threads/list-group-by-messes-up-pdf-output.42576/
