### PR TITLE
Import CSV - change slashes to work with windows.

### DIFF
--- a/plugins/fabrik_cron/importcsv/importcsv.php
+++ b/plugins/fabrik_cron/importcsv/importcsv.php
@@ -122,7 +122,7 @@ class PlgFabrik_Cronimportcsv extends PlgFabrik_Cron
 		$origListId = $input->getInt('listid', -1);
 
 		// Fabrik use this as the base directory, so we need a new directory under 'media'
-		define("FABRIK_CSV_IMPORT_ROOT", JPATH_ROOT . '/media');
+		define("FABRIK_CSV_IMPORT_ROOT", str_replace('\\', '/', JPATH_ROOT . '/media'));
 		$d = FABRIK_CSV_IMPORT_ROOT . '/' . $cronDir;
 
 		// TODO: Need to also have a FILTER for CSV files ONLY.
@@ -136,6 +136,7 @@ class PlgFabrik_Cronimportcsv extends PlgFabrik_Cron
 
 		foreach ($files as $fullCsvFile)
 		{
+			$fullCsvFile = str_replace('\\', '/', $fullCsvFile);
 			if (++$xfiles > $maxFiles)
 			{
 				break;


### PR DESCRIPTION
Needed for windows otherwise...

// Grab the CSV file, need to strip import root off path first
   $csvFile = str_replace(FABRIK_CSV_IMPORT_ROOT, '', $fullCsvFile);

... doesn't work.