### PR TITLE
[FIX] Fullcalendar canDelete call.

### DIFF
--- a/plugins/fabrik_visualization/fullcalendar/models/fullcalendar.php
+++ b/plugins/fabrik_visualization/fullcalendar/models/fullcalendar.php
@@ -486,9 +486,9 @@ class FabrikModelFullcalendar extends FabrikFEModelVisualization
 							$row->custom = $customUrl != '';
 							$row->_listid = $table->id;
 							$row->_formid = $table->form_id;
-							$row->_canDelete = (bool) $listModel->canDelete();
+							$row->_canDelete = (bool) $listModel->canDelete($row);
 							$row->_canEdit = (bool) $listModel->canEdit($row);
-							$row->_canView = (bool) $listModel->canViewDetails();
+							$row->_canView = (bool) $listModel->canViewDetails($row);
 
 							//Format local dates toISO8601
 							$mydate = new DateTime($row->startdate);


### PR DESCRIPTION
The calls to canDelete and canView did not include the row data. The canDelete was returning false even though the userID should have delete rights.