### PR TITLE
Update list.xml with group_by_show_count option

### DIFF
--- a/administrator/components/com_fabrik/models/forms/list.xml
+++ b/administrator/components/com_fabrik/models/forms/list.xml
@@ -265,6 +265,17 @@
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
+			
+			<field name="group_by_show_count"
+				type="radio"
+				class="btn-group"
+				default="1"
+				label="COM_FABRIK_FIELD_GROUP_BY_SHOW_COUNT_LABEL"
+				description="COM_FABRIK_FIELD_GROUP_BY_SHOW_COUNT_DESC"
+			>
+				<option value="0">JNO</option>
+				<option value="1">JYES</option>
+			</field>			
 
 		</fieldset>
 


### PR DESCRIPTION
Option to show/hide the group_by (count) shown in heading - which really doesn't work well in paginated lists anyhow - and only confuses the user.