### PR TITLE
 conditionally add groupCount in group-by-heading

### DIFF
--- a/components/com_fabrik/layouts/list/fabrik-group-by-heading.php
+++ b/components/com_fabrik/layouts/list/fabrik-group-by-heading.php
@@ -23,7 +23,11 @@ $imgProps = array('alt' => FText::_('COM_FABRIK_TOGGLE'), 'data-role' => 'toggle
 		<?php endif; ?>
 		<?php echo FabrikHelperHTML::image('arrow-down.png', 'list', $d->tmpl, $imgProps); ?>
 		<span class="groupTitle">
-			<?php echo $d->title; ?> <span class="groupCount">( <?php echo $d->count ?> )</span>
+			<?php echo $d->title; ?> 
+			<?php $d->group_by_show_count = isset($d->group_by_show_count) ? $d->group_by_show_count : '1'; 
+			if ($d->group_by_show_count) : ?>
+				<span class="groupCount">( <?php echo $d->count ?> )</span>
+			<?php endif; ?>			
 		</span>
 	</a>
 


### PR DESCRIPTION
Was careful to code this so that existing list configurations need not be edited for this to work.
I always hated that count being being put there and no way to remove it! Especially since it is a real confusing mess if multiple pages and pagination is used.