### PR TITLE
Update inlineedit.js

### DIFF
--- a/plugins/fabrik_list/inlineedit/inlineedit.js
+++ b/plugins/fabrik_list/inlineedit/inlineedit.js
@@ -81,7 +81,7 @@ var FbListInlineEdit = new Class({
 		
 		// Click outside list clears down selection
 		window.addEvent('click', function (e) {
-			if(typeof this.activeElement !== 'null') {
+			if(this.activeElement !== 'null') {
 				this.save(this.activeElement, this.editing, 'clicked');
 			}
 
@@ -154,7 +154,6 @@ var FbListInlineEdit = new Class({
 
 	checkKey: function (e) {
 		var nexttds, row, index;
-		var doTab = false;
 		if (typeOf(this.td) !== 'element') {
 			return;
 		}
@@ -186,7 +185,7 @@ var FbListInlineEdit = new Class({
 				} else {
 					this.edit(e, this.td);
 				}
-			}else{
+			} else {
 				e.stop();
 				this.inedit = false;
 				this.select(e, this.getNextEditable(this.td));
@@ -211,7 +210,7 @@ var FbListInlineEdit = new Class({
 				}
 			}
 			row = this.td.getParent();
-			this.downaction(e,row);
+			this.downaction(e, row);
 			break;
 		case 38:
 			//up
@@ -223,7 +222,7 @@ var FbListInlineEdit = new Class({
 				}
 			}
 			row = this.td.getParent();
-			this.upaction(e,row);
+			this.upaction(e, row);
 			break;
 		case 27:
 			//escape
@@ -259,7 +258,7 @@ var FbListInlineEdit = new Class({
 		}
 	},
 	
-	downaction: function(e,row) {
+	downaction: function(e, row) {
 		if (typeOf(row) === 'null') {
 			return;
 		}
@@ -271,7 +270,7 @@ var FbListInlineEdit = new Class({
 		}		
 	},
 	
-	upaction: function(e,row) {
+	upaction: function(e, row) {
 		if (typeOf(row) === 'null') {
 			return;
 		}
@@ -711,17 +710,17 @@ var FbListInlineEdit = new Class({
 				this.stopEditing();
 				this.saving = false;
 				
-				switch(action){
+				switch(action) {
 					case 'clicked':				
 						jQuery('td.focusClass').click();
 						break;
 					case 'down':
 						row = td.getParent();
-						this.downaction(e,row);
+						this.downaction(e, row);
 						break;
 					case 'up':
 						row = td.getParent();
-						this.upaction(e,row);
+						this.upaction(e, row);
 						break;
 					default:
 						break;

--- a/plugins/fabrik_list/inlineedit/inlineedit.js
+++ b/plugins/fabrik_list/inlineedit/inlineedit.js
@@ -79,9 +79,18 @@ var FbListInlineEdit = new Class({
 			this.setFocus(this.editCell);
 		}.bind(this));
 		
-		// Click outside list clears down selection
+		// Activate edit mode in clicked element
 		window.addEvent('click', function (e) {
-			if(this.activeElement !== 'null') {
+			
+			// check to see if clicked element is already in edit mode
+			var activeClassName	= this.activeElement.target.className;
+			var activeClasses = activeClassName.split(" ");
+			if (activeClasses[0] == e.target.id){
+				return;
+			}
+			
+			// First save current current edit if there is one
+			if (this.activeElement !== null) {	
 				this.save(this.activeElement, this.editing, 'clicked');
 			}
 

--- a/plugins/fabrik_list/inlineedit/inlineedit.js
+++ b/plugins/fabrik_list/inlineedit/inlineedit.js
@@ -92,7 +92,7 @@ var FbListInlineEdit = new Class({
 					this.cancel(e);	
 					return false;			
 				}
-			}else{
+			} else {
 				if (e.target.hasClass('focusClass') && this.inedit) {
 					var newtd = this.td;
 					this.select(e, this.editing);

--- a/plugins/fabrik_list/inlineedit/inlineedit.js
+++ b/plugins/fabrik_list/inlineedit/inlineedit.js
@@ -82,15 +82,14 @@ var FbListInlineEdit = new Class({
 		// Activate edit mode in clicked element
 		window.addEvent('click', function (e) {
 			
-			// check to see if clicked element is already in edit mode
-			var activeClassName	= this.activeElement.target.className;
-			var activeClasses = activeClassName.split(" ");
-			if (activeClasses[0] == e.target.id){
-				return;
-			}
-			
 			// First save current current edit if there is one
 			if (this.activeElement !== null) {	
+				// check to see if clicked element is already in edit mode
+				var activeClassName	= this.activeElement.target.className;
+				var activeClasses = activeClassName.split(" ");
+				if (activeClasses[0] == e.target.id){
+					return;
+				}
 				this.save(this.activeElement, this.editing, 'clicked');
 			}
 
@@ -101,7 +100,7 @@ var FbListInlineEdit = new Class({
 					this.cancel(e);	
 					return false;			
 				}
-			} else {
+			}else{
 				if (e.target.hasClass('focusClass') && this.inedit) {
 					var newtd = this.td;
 					this.select(e, this.editing);
@@ -177,7 +176,7 @@ var FbListInlineEdit = new Class({
 			}
 			break;
 		case 39:
-			//right
+			// right
 			if (this.inedit) {
 				return;
 			}
@@ -187,6 +186,7 @@ var FbListInlineEdit = new Class({
 			}
 			break;
 		case 9:
+			// tab
 			if (this.inedit && this.options.tabSave) {
 				if (typeOf(this.editing) === 'element') {
 					this.save(e, this.editing);
@@ -200,7 +200,7 @@ var FbListInlineEdit = new Class({
 				this.select(e, this.getNextEditable(this.td));
 			}
 			break;
-		case 37: //left
+		case 37: // left
 			if (this.inedit) {
 				return;
 			}
@@ -210,7 +210,7 @@ var FbListInlineEdit = new Class({
 			}
 			break;
 		case 40:
-			//down
+			// down
 			if (this.inedit && this.options.tabSave) {
 				if (typeOf(this.editing) === 'element') {
 					this.save(e, this.editing, 'down');
@@ -222,7 +222,7 @@ var FbListInlineEdit = new Class({
 			this.downaction(e, row);
 			break;
 		case 38:
-			//up
+			// up
 			if (this.inedit && this.options.tabSave) {
 				if (typeOf(this.editing) === 'element') {
 					this.save(e, this.editing, 'up');
@@ -234,7 +234,7 @@ var FbListInlineEdit = new Class({
 			this.upaction(e, row);
 			break;
 		case 27:
-			//escape
+			// escape
 			e.stop();
 			if (!this.inedit) {
 				this.td.removeClass(this.options.focusClass);
@@ -245,7 +245,7 @@ var FbListInlineEdit = new Class({
 			}
 			break;
 		case 13:
-			//enter
+			// enter
 			// Already editing or no cell selected
 			if (typeOf(this.td) !== 'element') {
 				return;
@@ -353,7 +353,7 @@ var FbListInlineEdit = new Class({
 	},
 
 	isEditable: function (cell) {
-		if (typeof cell === 'undefined'){
+		if (Boolean(cell) === false){	
 			return false;
 		}
 		if (cell.hasClass('fabrik_uneditable') || cell.hasClass('fabrik_ordercell') || cell.hasClass('fabrik_select') || cell.hasClass('fabrik_actions')) {
@@ -628,7 +628,6 @@ var FbListInlineEdit = new Class({
 	},
 
 	save: function (e, td, action) {
-		
 		if(typeof td === 'undefined'){
 			this.cancel(e);
 			return false;
@@ -718,7 +717,6 @@ var FbListInlineEdit = new Class({
 				Fabrik.fireEvent('fabrik.list.updaterows');
 				this.stopEditing();
 				this.saving = false;
-				
 				switch(action) {
 					case 'clicked':				
 						jQuery('td.focusClass').click();


### PR DESCRIPTION
I have worked at getting the Inline Edit list plugin to work much more like a spreadsheet (as advertised).
Details of these changes...

If not in Edit mode...

```
If any element/cell is clicked, then that cell gains focus and is put in edit mode.

Pressing the Spacebar or Enter Key will put that element/cell in edit mode.

If Up/Down arrow keys are pressed, the element/cell above or below receives focus. 

If the Tab or Right Arrow key is pressed, the focus is moved to the next element/cell (left-to-right) UNLESS the column is the last editable column - in which case the focus moves down to the first editable column in the next row below.

If the Left Arrow key is pressed, the focus is moved to the previous element/cell (right-to-left) UNLESS the column is the first editable column - in which case the focus moves up to the last editable column in the previous row above. 
```

If in edit mode (and 'save on tab' is set)...

```
Clicking another editable element/cell saves the current edit and moves the focus to the newly selected element in edit mode.

If Up/Down arrows are pressed, the value is saved and the element/cell above or below receives focus. 

If the Tab Key is pressed OR the Enter key is pressed (and not a textarea element), the value is saved and focus moves to the next editable element/cell - unless it is already the last editable element in the row, in which case the focus moves to the first editable element in the next row below.
```

**\* I used css to change the text color of all editable columns, in order to distinguish them from non-editable columns. I'm not sure if you'd want that as an option/parameter in the xml for the plugin itself, but I think it would be a good idea. E.g. 'Editable columns color:"
