### PR TITLE
jUser: get group title for single group id

### DIFF
--- a/plugins/fabrik_form/juser/juser.php
+++ b/plugins/fabrik_form/juser/juser.php
@@ -206,14 +206,22 @@ class PlgFabrik_FormJUser extends plgFabrik_Form
 							$groupElement      = FabrikWorker::getPluginManager()->getElementPlugin($params->get('juser_field_usertype'));
 							$groupElementClass = get_class($groupElement);
 							$gid               = $user->groups;
+							$groupLabels	= $gid;
 
 							if ($groupElementClass !== 'PlgFabrik_ElementUsergroup')
 							{
 								$gid = array_shift($gid);
+								//Get group title
+								$grdb = JFactory::getDbo();
+								$grquery = $grdb->getQuery(true);
+								$grquery->select('title')->from('#__usergroups')->where('id =' . $gid);
+								$grdb->setQuery($grquery);
+
+								$groupLabels = $grdb->loadResult();
 							}
 
 							$this->gidfield                            = $this->getFieldName('juser_field_usertype');
-							$formModel->data[$this->gidfield]          = $gid;
+							$formModel->data[$this->gidfield]          = $groupLabels;
 							$formModel->data[$this->gidfield . '_raw'] = $gid;
 						}
 


### PR DESCRIPTION
jUser needs the userGroups element to handle multiple groups.

Any other element type used for usergroups sync is reducing the user groups to only one group and was setting element + element_raw = groupid.
I didn't find a J! function to get the group title.

http://fabrikar.com/forums/index.php?threads/databasejoin-element-showing-raw-value-in-detail-view.43627/#post-223637