### PR TITLE
Update csvexport.php to include alternative processing

### DIFF
--- a/components/com_fabrik/models/csvexport.php
+++ b/components/com_fabrik/models/csvexport.php
@@ -394,27 +394,31 @@ class FabrikFEModelCSVExport extends FabModel
 		jimport('joomla.filesystem.file');
 		$filename = $this->getFileName();
 		$filePath = $this->getFilePath();
-		$document = JFactory::getDocument();
-		$document->setMimeEncoding('application/zip');
-		$str = $this->getCSVContent();
-		$this->app->clearHeaders();
-		$encoding = $this->getEncoding();
+		$listid = $this->app->input->getInt('listid');
+		if(file_exists(JPATH_PLUGINS.'/fabrik_list/listcsv/scripts/list_'.$listid.'_csv_export.php')){	
+			require(JPATH_PLUGINS.'/fabrik_list/listcsv/scripts/list_260_csv_export.php');
+		}else{			
+			$document = JFactory::getDocument();
+			$document->setMimeEncoding('application/zip');
+			$str = $this->getCSVContent();
+			$this->app->clearHeaders();
+			$encoding = $this->getEncoding();
 
-		// Set the response to indicate a file download
-		$this->app->setHeader('Content-Type', 'application/zip');
-		$this->app->setHeader('Content-Disposition', "attachment;filename=\"" . $filename . "\"");
+			// Set the response to indicate a file download
+			$this->app->setHeader('Content-Type', 'application/zip');
+			$this->app->setHeader('Content-Disposition', "attachment;filename=\"" . $filename . "\"");
 
-		// Xls formatting for accents
-		if ($this->outPutFormat == 'excel')
-		{
-			$this->app->setHeader('Content-Type', 'application/vnd.ms-excel');
+			// Xls formatting for accents
+			if ($this->outPutFormat == 'excel')
+			{
+				$this->app->setHeader('Content-Type', 'application/vnd.ms-excel');
+			}
+
+			$this->app->setHeader('charset', $encoding);
+			$this->app->setBody($str);
+			echo $this->app->toString(false);
+			JFile::delete($filePath);
 		}
-
-		$this->app->setHeader('charset', $encoding);
-		$this->app->setBody($str);
-		echo $this->app->toString(false);
-		JFile::delete($filePath);
-
 		// $$$ rob 21/02/2012 - need to exit otherwise Chrome give 349 download error
 		exit;
 	}


### PR DESCRIPTION
This is a pretty simple addition of an if condition that would accommodate (at least half of) my long-standing problem regarding the need to provide a TRUE Excel spreadsheet from a  Fabrik list. It’s just a few lines of code and it doesn’t affect anything else in Fabrik. 

What this would do is implement the inclusion of a php script that acts as a replacement for the routine run by Fabrik in the downloadFile() function of csvexprt.php.  Look at it as an extension/alternative for the listcsv plugin.

The inclusion and success of the Export is based on one simple rule (Just like what is done for form_x.js, list_x.js, and details.js files.) If the file exists “./plugins/fabrik_list/listcsv/scripts/list_[ListID]_csv_export.php”, then that file is imported via php require() rather than the normal downloadFile() processing done by Fabrik.

For example,in my php script I use phpExcel to transform the CSV file into an xlsx file – adding my own formatting, password protection, locks and freezes on certain columns or rows of the spreadsheet.

It works for me - and I think it would be a good addition to Fabrik. This wouldn’t have to be used just for Excel files, using the phpExcel library. It could be used to create any kind of file based on the data in the CSV file – using whatever 3rd party tool (like phpExcel) is required to do so.
I’ll post an example of how to use it with phpExcel in the Wiki, once I see that you have committed my pull request.