### PR TITLE
Update group.php

### DIFF
--- a/components/com_fabrik/models/group.php
+++ b/components/com_fabrik/models/group.php
@@ -363,7 +363,14 @@ class FabrikFEModelGroup extends FabModel
 				 * $$$ rob Using @ for now as in inline edit in podion you get multiple notices when
 				* saving the status element
 				*/
-				$this->elements = @$allGroups[$this->getId()]->elements;
+				/* Bauer note: this error prevents adding new elements 
+				 * in a new list (where Id is not yet known) in php 7 
+				 */
+				// $this->elements = @$allGroups[$this->getId()]->elements;
+				$thisId = $this->getId();
+				if(!empty($thisId)){
+					$this->elements = $allGroups[$thisId]->elements;
+				}
 			}
 		}
 


### PR DESCRIPTION
Gets past error that freezes javascript and prevents a new list from being added.
See http://fabrikar.com/forums/index.php?threads/new-list-element-content-options-not-shown-now-cannot-delete-list.43823/