### PR TITLE
disable options query for hidden fabrik user element

### DIFF
--- a/plugins/fabrik_element/user/user.php
+++ b/plugins/fabrik_element/user/user.php
@@ -1076,4 +1076,23 @@ class PlgFabrik_ElementUser extends PlgFabrik_ElementDatabasejoin
 
 		return array($ar);
 	}
+
+	/**
+	 * Create the sql query used to get the join data
+	 *
+	 * @param   array $data     data
+	 * @param   bool  $incWhere include where
+	 * @param   array $opts     query options
+	 *
+	 * @return  mixed    JDatabaseQuery or false if query can't be built
+	 */
+	protected function buildQuery($data = array(), $incWhere = true, $opts = array())
+	{
+		if ($this->isHidden())
+		{
+			return false;
+		}
+
+		return parent::buildQuery($data, $incWhere, $opts);
+	}
 }


### PR DESCRIPTION
User element plugin loads dropdown query for hidden element that must just insert current user ID.
Does it make sense?