### PR TITLE
Adds menu options for CSV Import extensions, overwrite, and dropdata

### DIFF
--- a/components/com_fabrik/views/list/tmpl/default.xml
+++ b/components/com_fabrik/views/list/tmpl/default.xml
@@ -200,7 +200,18 @@
 			       description="COM_FABRIK_FIELD_CSV_IMPORT_EXTENSIONS_DESC"
 			/>              
             
-			<field name="csv_import_dropdata"
+		        <field name="csv_import_sil_only"
+ 				type="radio"
+ 				class="btn-group"
+ 				default="0"
+ 				description="COM_FABRIK_FIELD_CSV_IMPORT_SIL_ONLY_DESC"
+ 				label="COM_FABRIK_FIELD_CSV_IMPORT_SIL_ONLY_LABEL"
+ 			>
+ 					<option value="0">JNO</option>
+ 					<option value="1">JYES</option>
+ 			</field>            
+            
+			field name="csv_import_dropdata"
 				type="radio"
 				class="btn-group"
 				default="0"

--- a/components/com_fabrik/views/list/tmpl/default.xml
+++ b/components/com_fabrik/views/list/tmpl/default.xml
@@ -189,8 +189,40 @@
 				size="5"
 				label="COM_FABRIK_MENU_CSV_POPUP_OPTS_WIDTH_LABEL"
 				description="COM_FABRIK_MENU_CSV_POPUP_OPTS_WIDTH_DESC"
-			/>	
+			/>
 			
+			<field name="csv_import_extensions"
+			       type="text"
+			       class="input-medium"
+			       size="20"
+			       default="txt,csv,tsv"
+			       label="COM_FABRIK_FIELD_CSV_IMPORT_EXTENSIONS_LABEL"
+			       description="COM_FABRIK_FIELD_CSV_IMPORT_EXTENSIONS_DESC"
+			/>              
+            
+			<field name="csv_import_dropdata"
+				type="radio"
+				class="btn-group"
+				default="0"
+				description="COM_FABRIK_FIELD_CSV_IMPORT_DROPDATA_DESC"
+				label="COM_FABRIK_FIELD_CSV_IMPORT_DROPDATA_LABEL"
+			>
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+			</field>
+            
+            
+			<field name="csv_import_overwrite"
+				type="radio"
+				class="btn-group"
+				default="0"
+				description="COM_FABRIK_FIELD_CSV_IMPORT_OVERWRITE_DESC"
+				label="COM_FABRIK_FIELD_CSV_IMPORT_OVERWRITE_LABEL"
+			>
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+			</field>
+
 			<!-- <field name="query_string"
 				type="text"
 				class="input-xlarge"


### PR DESCRIPTION
For CSV Import, The Overwrite and Dropdata options were basically hard-coded as 0 and could not be set (even in the list configuration). This caused errors when trying to import into existing data. Added as menu options to better allow for individual page (list filter and 'Show in list') settings.

The 'Allowed file extensions' option allows for any type of file to be uploaded (and can be used with an included list_##\_csv_import.php file for pre-processing uploaded file and converting to csv (e.g. using phpExcel to convert an uploaded xlsx file to csv) - similar to what was done for CSV Export using list_##\_csv_export.php files for post-processing CSV exports.