### PR TITLE
Fixing wrong logic in getFilterQuery

### DIFF
--- a/plugins/fabrik_element/databasejoin/databasejoin.php
+++ b/plugins/fabrik_element/databasejoin/databasejoin.php
@@ -2608,10 +2608,10 @@ class PlgFabrik_ElementDatabasejoin extends PlgFabrik_ElementList
 
 					if (!empty($rows))
 					{
-						// Either look for the parent_ids in the main fabrik list or the group's list.
+						// Either look for the ids in the main fabrik list or the group's list.
 						$groupJoinModel = $group->getJoinModel();
-						$groupFk        = $groupJoinModel->getForeignKey('.');
-						$lookupTable    = $group->isJoin() ? $groupFk : $this->getListModel()->getPrimaryKey();
+						$groupPk        = $groupJoinModel->getForeignID('.');
+						$lookupTable    = $group->isJoin() ? $groupPk : $this->getListModel()->getPrimaryKey();
 						$str            = $lookupTable . ' IN (' . implode(', ', $joinIds) . ')';
 					}
 					else


### PR DESCRIPTION
When the element is multijoin in joined group then filter was looking for joined table fk but actually it should look for joined table pk (as it looks for the main table pk when multijoin is in main data group). Filtering multijoin element had no results as it looked for wrong data. This fix works for both dbjoin and CDD (and also tags element that needs, however, more fixes).