### PR TITLE
Place plugin top buttons above list

### DIFF
--- a/administrator/components/com_fabrik/models/forms/list.xml
+++ b/administrator/components/com_fabrik/models/forms/list.xml
@@ -1024,6 +1024,17 @@
 				<option value="1">JYES</option>
 			</field>
 
+			<field name="plugins-above"
+			       type="radio"
+			       class="btn-group"
+			       default="0"
+			       label="COM_FABRIK_PLUGINS_ABOVE_LABEL"
+			       description="COM_FABRIK_PLUGINS_ABOVE_DESC"
+			>
+				<option value="0">JNO</option>
+				<option value="1">JYES</option>
+			</field>
+
 		</fieldset>
 
 		<fieldset name="layout-bootstrap">

--- a/components/com_fabrik/models/plugin-list.php
+++ b/components/com_fabrik/models/plugin-list.php
@@ -148,8 +148,19 @@ class PlgFabrik_List extends FabrikPlugin
 
 
 			$img = FabrikHelperHTML::image($imageName, 'list', $tmpl, $properties, false, $opts);
-			$text = $this->buttonAction == 'dropdown' ? $label : '<span class="hidden">' . $label . '</span>';
-
+			
+			if (strstr($label, '|'))
+			{
+				$label = explode('|', $label);
+				$text = $this->buttonAction == 'dropdown' ? $label[1] : $label[0] . '<span class="hidden">' . $label[1] . '</span>';
+				$title = $label[1];
+			}
+			else
+			{
+				$text = $this->buttonAction == 'dropdown' ? $label : '<span class="hidden">' . $label . '</span>';				
+				$title = $label;
+			}
+			
 			if ($j3 && $this->buttonAction != 'dropdown')
 			{
 				$layout = FabrikHelperHTML::getLayout('fabrik-button');

--- a/components/com_fabrik/views/list/tmpl/bootstrap/default_headings.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap/default_headings.php
@@ -17,13 +17,26 @@ $layoutData = (object) array(
 	'name' => 'filter',
 	'label' => FabrikHelperHTML::icon('icon-filter', FText::_('COM_FABRIK_GO'))
 );
-?>
+
+foreach ($this->headings as $key => $heading) :
+	$h = $this->headingClass[$key];
+	
+	if (strstr($heading, 'listplugin') && $this->pluginsAbove): ?>
+	<div style="text-align: right;">
+	<?php echo $heading;?>
+	</div>
+<?php endif; ?>
+<?php endforeach; ?>
+
 	<tr class="fabrik___heading">
 		<?php foreach ($this->headings as $key => $heading) :
 			$h = $this->headingClass[$key];
 			$style = empty($h['style']) ? '' : 'style="' . $h['style'] . '"'; ?>
 			<th class="heading <?php echo $h['class'] ?>" <?php echo $style ?>>
+			<?php 	
+			if ((!strstr($heading, 'listplugin') && $this->pluginsAbove) || !$this->pluginsAbove): ?>
 				<span><?php echo $heading; ?></span>
+			<?php endif; ?>
 			</th>
 		<?php endforeach; ?>
 	</tr>

--- a/components/com_fabrik/views/list/view.base.php
+++ b/components/com_fabrik/views/list/view.base.php
@@ -586,6 +586,7 @@ class FabrikViewListBase extends FabrikView
 
 		$this->buttons();
 		$this->pluginTopButtons = $model->getPluginTopButtons();
+		$this->pluginsAbove = (bool) $this->params->get('plugins-above', false);
 	}
 
 	/**


### PR DESCRIPTION
and show text if needed.
Fixes a situation when you need many list plugins for different actions, 
It's often also difficult to find the right icon that could exactly express the purpose of the plugin. Users may want to use full or short labels instead (or near a standard icon). 