### PR TITLE
fix list layout name

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -10866,7 +10866,7 @@ class FabrikFEModelList extends JModelForm
 			}
 			else
 			{
-				$this->tmpl = $input->get('layout', $item->template);
+				$this->tmpl = basename($input->get('layout', $item->template, 'RAW'));
 
 				if ($this->app->scope !== 'mod_fabrik_list')
 				{


### PR DESCRIPTION
Change layout name: `varwwwhtmlcomponentscom_fabrikviewslisttmpldiv` -> `div`

``` php
$this->tmpl = $input->get('layout', $item->template);
```

->

``` php
$this->tmpl = basename($input->get('layout', $item->template, 'RAW'));
```
