### PR TITLE
fix: Fileupload - delete file didn't work in IE and Edge

### DIFF
--- a/plugins/fabrik_element/fileupload/fileupload.js
+++ b/plugins/fabrik_element/fileupload/fileupload.js
@@ -684,7 +684,7 @@ define(['jquery', 'fab/fileelement'], function (jQuery, FbFileElement) {
                     'repeatCounter': this.options.repeatCounter
                 }
             });
-            var li = e.target.closest('.plupload_delete');
+            var li = jQuery(e.target).closest('.plupload_delete');
             li.remove();
 
             // Remove hidden fields as well


### PR DESCRIPTION
Trying to delete a file on a fileupload element in IE or Edge led to an error: "Object doesn't support property or method 'closest'" because "e.target" wasn't a jQuery object.