### PR TITLE
Ajax-fileupload: if file is no image open in new window

### DIFF
--- a/plugins/fabrik_element/fileupload/fileupload.js
+++ b/plugins/fabrik_element/fileupload/fileupload.js
@@ -405,7 +405,8 @@ define(['jquery', 'fab/fileelement'], function (jQuery, FbFileElement) {
                             } else {
                                 a = jQuery(document.createElement('span'));
                                 title = jQuery(document.createElement('a')).attr({
-                                    'href': file.url
+                                    'href': file.url,
+			      'target': '_blank'
                                 }).text(file.name);
                             }
 


### PR DESCRIPTION
In form view: if file is no image open in new window (images are opened in a popup anyway)

fileupload.js has still to be minified