### PR TITLE
fix textarea-wysiwyg charsLeft display

### DIFF
--- a/plugins/fabrik_element/textarea/layouts/fabrik-element-textarea-wysiwyg/charsleft.php
+++ b/plugins/fabrik_element/textarea/layouts/fabrik-element-textarea-wysiwyg/charsleft.php
@@ -1,0 +1,11 @@
+<?php
+
+defined('JPATH_BASE') or die;
+
+// Add span with id so that element fxs work.
+$d = $displayData;
+?>
+
+<div class="fabrik_characters_left muted" style="clear:both"><span class="badge"><?php echo $d->charsLeft;?></span>
+<?php echo $d->charsLeftLabel;?>
+</div>


### PR DESCRIPTION
The "charsleft" sublayout was not available for the fabrik-element-textarea-wysiwyg layout.
Creating a copy of the fabrik-element-textarea-form sublayout solves this.