### PR TITLE
fix: multiple joins- common table_join query error

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -2462,13 +2462,13 @@ class FabrikFEModelList extends JModelForm
 						{
 							$v = str_replace('`', '', $tmpPks[$pk][0]);
 							$v = explode('.', $v);
-							$v[0] = $v[0] . '_0';
+							// $v[0] = $v[0] . '_0';
 							$tmpPks[$pk][0] = $db->qn($v[0] . '.' . $v[1]);
 						}
 
 						$v = str_replace('`', '', $pk);
 						$v = explode('.', $v);
-						$v[0] = $v[0] . '_' . count($tmpPks[$pk]);
+						$v[0] = $v[0] . '_' . (count($tmpPks[$pk]) == 0 ? '' : count($tmpPks[$pk]) - 1);
 						$tmpPks[$pk][] = $db->qn($v[0] . '.' . $v[1]);
 					}
 				}


### PR DESCRIPTION
When multiple list joins have similar table_join and list joined data is merged / reduced
then table aliases in SELECT statement and JOIN statement have numbered differently in mergejoineddata query which produces error.
See an example 

![image](https://cloud.githubusercontent.com/assets/1138055/24154758/bd4ff4ac-0e5a-11e7-97bc-19300289bd1b.png)
