### PR TITLE
HTML entities in fabrikElementReadOnly

### DIFF
--- a/components/com_fabrik/models/element.php
+++ b/components/com_fabrik/models/element.php
@@ -2412,7 +2412,7 @@ class PlgFabrik_Element extends FabrikPlugin
 			// $$$ rob changed from span wrapper to div wrapper as element's content may contain divs which give html error
 
 			// Placeholder to be updated by ajax code
-			$v = $this->getROElement($data, $repeatCounter);
+			$v = html_entity_decode($this->getROElement($data, $repeatCounter));
 			//$v = $v == '' ? '&nbsp;' : $v;
 
 			return '<div class="fabrikElementReadOnly" id="' . $htmlId . '">' . $v . '</div>';


### PR DESCRIPTION
Add html_entity_decode function to content of div for readonly element created if validation fails; else htmlentities (such as any html embedded in databasejoin 'Or Concat label') may be shown in div.fabrikElementReadOnly.