### PR TITLE
Merge rows alternative

### DIFF
--- a/components/com_fabrik/models/element.php
+++ b/components/com_fabrik/models/element.php
@@ -683,7 +683,17 @@ class PlgFabrik_Element extends FabrikPlugin
 						}
 
 						$data = htmlspecialchars($data, ENT_QUOTES);
-						$img  = '<a class="fabrikTip" ' . $target . ' href="' . $aHref . '" opts=\'' . $opts . '\' title="' . $data . '">' . $img . '</a>';
+
+						$layout                  = FabrikHelperHTML::getLayout('element.fabrik-element-listicon-tip');
+						$displayData             = new stdClass;
+						$displayData->img     = $img;
+						$displayData->title   = $data;
+						$displayData->href    = $aHref;
+						$displayData->target  = $target;
+						$displayData->opts    = $opts;
+						$img                  = $layout->render($displayData);
+
+						//$img  = '<a class="fabrikTip" ' . $target . ' href="' . $aHref . '" opts=\'' . $opts . '\' title="' . $data . '">' . $img . '</a>';
 					}
 					elseif (!empty($iconFile))
 					{
@@ -910,11 +920,11 @@ class PlgFabrik_Element extends FabrikPlugin
 	 *
 	 * @return string
 	 */
-	protected function groupConcactJoinKey()
+	public function groupConcactJoinKey()
 	{
 		$table = $this->getListModel()->getTable();
 
-		if ($this->getGroupModel()->isJoin() && $this->isJoin())
+		if ($this->getGroupModel()->isJoin()) //  && $this->isJoin()
 		{
 			$groupJoin = $this->getGroupModel()->getJoinModel()->getJoin();
 			$pkField   = $groupJoin->params->get('pk');
@@ -2285,6 +2295,10 @@ class PlgFabrik_Element extends FabrikPlugin
 				break;
 		}
 
+		$primary = $this->groupConcactJoinKey();
+		$element->primary = FabrikString::safeColNameToArrayKey($primary);
+		$element->isPK = $this->getFullName() == $element->primary;
+		
 		return $element;
 	}
 

--- a/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/custom_css_example.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/custom_css_example.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Fabrik List Template: Default Custom CSS
+ *
+ * @package     Joomla
+ * @subpackage  Fabrik
+ * @copyright   Copyright (C) 2005-2016  Media A-Team, Inc. - All rights reserved.
+ * @license     GNU/GPL http://www.gnu.org/copyleft/gpl.html
+ */
+
+/**
+* If you need to make small adjustments or additions to the CSS for a Fabrik
+* list template, you can create a custom_css.php file, which will be loaded after
+* the main template_css.php for the template.
+*
+* This file will be invoked as a PHP file, so the list ID
+* can be used in order to narrow the scope of any style changes.  You do
+* this by prepending #listform_$c to any selectors you use.  This will become
+* (say) #listform_12, owhich will be the HTML ID of your list on the page.
+*
+* See examples below, which you should remove if you copy this file.
+*
+* Don't edit anything outside of the BEGIN and END comments.
+*
+* For more on custom CSS, see the Wiki at:
+*
+* http://www.fabrikar.com/forums/index.php?wiki/form-and-details-templates/#the-custom-css-file
+*
+* NOTE - for backward compatibility with Fabrik 2.1, and in case you
+* just prefer a simpler CSS file, without the added PHP parsing that
+* allows you to be be more specific in your selectors, we will also include
+* a custom.css we find in the same location as this file.
+*
+*/
+
+header('Content-type: text/css');
+$c = $_REQUEST['c'];
+echo <<<EOT
+
+#listform_$c .fabrikForm {
+	margin-top: 25px !important;
+}
+
+EOT;

--- a/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Bootstrap List Template - Default
+ *
+ * @package     Joomla
+ * @subpackage  Fabrik
+ * @copyright   Copyright (C) 2005-2016  Media A-Team, Inc. - All rights reserved.
+ * @license     GNU/GPL http://www.gnu.org/copyleft/gpl.html
+ * @since       3.1
+ */
+
+// No direct access
+defined('_JEXEC') or die('Restricted access');
+
+$pageClass = $this->params->get('pageclass_sfx', '');
+
+if ($pageClass !== '') :
+	echo '<div class="' . $pageClass . '">';
+endif;
+
+
+if ($this->tablePicker != '') : ?>
+	<div style="text-align:right"><?php echo FText::_('COM_FABRIK_LIST') ?>: <?php echo $this->tablePicker; ?></div>
+<?php
+endif;
+
+if ($this->params->get('show_page_heading')) :
+	echo '<h1>' . $this->params->get('page_heading') . '</h1>';
+endif;
+
+if ($this->showTitle == 1) : ?>
+	<div class="page-header">
+		<h1><?php echo $this->table->label;?></h1>
+	</div>
+<?php
+endif;
+
+// Intro outside of form to allow for other lists/forms to be injected.
+echo $this->table->intro;
+
+?>
+<form class="fabrikForm form-search" action="<?php echo $this->table->action;?>" method="post" id="<?php echo $this->formid;?>" name="fabrikList">
+
+<?php
+if ($this->hasButtons):
+	echo $this->loadTemplate('buttons');
+endif;
+
+if ($this->showFilters && $this->bootShowFilters) :
+	echo $this->layoutFilters();
+endif;
+//for some really ODD reason loading the headings template inside the group
+//template causes an error as $this->_path['template'] doesn't contain the correct
+// path to this template - go figure!
+$headingsHtml = $this->loadTemplate('headings');
+echo $this->loadTemplate('tabs');
+?>
+
+<div class="fabrikDataContainer">
+
+<?php foreach ($this->pluginBeforeList as $c) :
+	echo $c;
+endforeach;
+?>
+	<table class="<?php echo $this->list->class;?>" id="list_<?php echo $this->table->renderid;?>" >
+		 <thead><?php echo $headingsHtml?></thead>
+		 <tfoot>
+			<tr class="fabrik___heading">
+				<td colspan="<?php echo count($this->headings);?>">
+					<?php echo $this->nav;?>
+				</td>
+			</tr>
+		 </tfoot>
+		<?php
+		if ($this->isGrouped && empty($this->rows)) :
+			?>
+			<tbody style="<?php echo $this->emptyStyle?>">
+				<tr>
+					<td class="groupdataMsg emptyDataMessage" style="<?php echo $this->emptyStyle?>" colspan="<?php echo count($this->headings)?>">
+						<div class="emptyDataMessage" style="<?php echo $this->emptyStyle?>">
+							<?php echo $this->emptyDataMessage; ?>
+						</div>
+					</td>
+				</tr>
+			</tbody>
+			<?php
+		endif;
+		$gCounter = 0;
+		$d = array();
+		foreach ($this->rows as $groupedBy => $group) :
+			if ($this->isGrouped) : ?>
+			<tbody>
+				<tr class="fabrik_groupheading info">
+					<td colspan="<?php echo $this->colCount;?>">
+						<?php echo $this->layoutGroupHeading($groupedBy, $group); ?>
+					</td>
+				</tr>
+			</tbody>
+			<?php endif ?>
+			<tbody class="fabrik_groupdata">
+				<tr style="<?php echo $this->emptyStyle?>">
+					<td class="groupdataMsg emptyDataMessage" style="<?php echo $this->emptyStyle?>" colspan="<?php echo count($this->headings)?>">
+						<div class="emptyDataMessage" style="<?php echo $this->emptyStyle?>">
+							<?php echo $this->emptyDataMessage; ?>
+						</div>
+					</td>
+				</tr>
+			<?php
+
+			foreach ($group as $this->_row) :
+				echo $this->loadTemplate('row');	
+			endforeach;
+		 	?>
+		 	</tbody>
+			<?php if ($this->hasCalculations) : ?>
+			<tfoot>
+				<tr class="fabrik_calculations">
+
+				<?php
+				foreach ($this->headings as $key => $heading) :
+					$h = $this->headingClass[$key];
+					$style = empty($h['style']) ? '' : 'style="' . $h['style'] . '"';?>
+					<td class="<?php echo $h['class']?>" <?php echo $style?>>
+						<?php
+						$cal = $this->calculations[$key];
+						echo array_key_exists($groupedBy, $cal->grouped) ? $cal->grouped[$groupedBy] : $cal->calc;
+						?>
+					</td>
+				<?php
+				endforeach;
+				?>
+
+				</tr>
+			</tfoot>
+			<?php endif ?>
+		<?php
+		$gCounter++;
+
+
+		endforeach;?>
+	</table>
+	<?php print_r($this->hiddenFields);
+?>
+</div>
+</form>
+<?php
+echo $this->table->outro;
+if ($pageClass !== '') :
+	echo '</div>';
+endif;
+?>

--- a/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_buttons.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_buttons.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Bootstrap List Template - Buttons
+ *
+ * @package     Joomla
+ * @subpackage  Fabrik
+ * @copyright   Copyright (C) 2005-2016  Media A-Team, Inc. - All rights reserved.
+ * @license     GNU/GPL http://www.gnu.org/copyleft/gpl.html
+ * @since       3.1
+ */
+
+// No direct access
+defined('_JEXEC') or die('Restricted access');
+
+?>
+<div class="fabrikButtonsContainer row-fluid">
+<ul class="nav nav-pills  pull-left">
+
+<?php if ($this->showAdd) :?>
+
+	<li><a class="addbutton addRecord" href="<?php echo $this->addRecordLink;?>">
+		<?php echo FabrikHelperHTML::icon('icon-plus', $this->addLabel);?>
+	</a></li>
+<?php
+endif;
+
+if ($this->showToggleCols) :
+	echo $this->loadTemplate('togglecols');
+endif;
+
+if ($this->canGroupBy) :
+
+	$displayData = new stdClass;
+	$displayData->icon = FabrikHelperHTML::icon('icon-list-view');
+	$displayData->label = FText::_('COM_FABRIK_GROUP_BY');
+	$displayData->links = array();
+	foreach ($this->groupByHeadings as $url => $obj) :
+		$displayData->links[] = '<a data-groupby="' . $obj->group_by . '" href="' . $url . '">' . $obj->label . '</a>';
+	endforeach;
+
+	$layout = $this->getModel()->getLayout('fabrik-nav-dropdown');
+	echo $layout->render($displayData);
+	?>
+
+
+<?php endif;
+if (($this->showClearFilters && (($this->filterMode === 3 || $this->filterMode === 4))  || $this->bootShowFilters == false)) :?>
+	<li>
+		<a class="clearFilters" href="#">
+			<?php echo FabrikHelperHTML::icon('icon-refresh', FText::_('COM_FABRIK_CLEAR'));?>
+		</a>
+	</li>
+<?php endif;
+if ($this->showFilters && $this->toggleFilters) :?>
+	<li>
+		<?php if ($this->filterMode === 5) :
+		?>
+			<a href="#filter_modal" data-toggle="modal">
+				<?php echo $this->buttons->filter;?>
+				<span><?php echo FText::_('COM_FABRIK_FILTER');?></span>
+			</a>
+				<?php
+		else:
+		?>
+		<a href="#" class="toggleFilters" data-filter-mode="<?php echo $this->filterMode;?>">
+			<?php echo $this->buttons->filter;?>
+			<span><?php echo FText::_('COM_FABRIK_FILTER');?></span>
+		</a>
+			<?php endif;
+		?>
+	</li>
+<?php endif;
+if ($this->advancedSearch !== '') : ?>
+	<li>
+		<a href="<?php echo $this->advancedSearchURL?>" class="advanced-search-link">
+			<?php echo FabrikHelperHTML::icon('icon-search', FText::_('COM_FABRIK_ADVANCED_SEARCH'));?>
+		</a>
+	</li>
+<?php endif;
+if ($this->showCSVImport || $this->showCSV) :?>
+	<?php
+	$displayData = new stdClass;
+	$displayData->icon = FabrikHelperHTML::icon('icon-upload');
+	$displayData->label = FText::_('COM_FABRIK_CSV');
+	$displayData->links = array();
+	if ($this->showCSVImport) :
+		$displayData->links[] = '<a href="' . $this->csvImportLink . '" class="csvImportButton">' . FabrikHelperHTML::icon('icon-download', FText::_('COM_FABRIK_IMPORT_FROM_CSV'))  . '</a>';
+	endif;
+	if ($this->showCSV) :
+		$displayData->links[] = '<a href="#" class="csvExportButton">' . FabrikHelperHTML::icon('icon-upload', FText::_('COM_FABRIK_EXPORT_TO_CSV')) . '</a>';
+	endif;
+	$layout = $this->getModel()->getLayout('fabrik-nav-dropdown');
+	echo $layout->render($displayData);
+	?>
+
+<?php endif;
+if ($this->showRSS) :?>
+	<li>
+		<a href="<?php echo $this->rssLink;?>" class="feedButton">
+		<?php echo FabrikHelperHTML::image('feed.png', 'list', $this->tmpl);?>
+		<?php echo FText::_('COM_FABRIK_SUBSCRIBE_RSS');?>
+		</a>
+	</li>
+<?php
+endif;
+if ($this->showPDF) :?>
+			<li><a href="<?php echo $this->pdfLink;?>" class="pdfButton">
+				<?php echo FabrikHelperHTML::icon('icon-file', FText::_('COM_FABRIK_PDF'));?>
+			</a></li>
+<?php endif;
+if ($this->emptyLink) :?>
+		<li>
+			<a href="<?php echo $this->emptyLink?>" class="doempty">
+			<?php echo $this->buttons->empty;?>
+			<?php echo FText::_('COM_FABRIK_EMPTY')?>
+			</a>
+		</li>
+<?php
+endif;
+?>
+</ul>
+<?php if (array_key_exists('all', $this->filters) || $this->filter_action != 'onchange') {
+?>
+<ul class="nav pull-right">
+	<li>
+	<div <?php echo $this->filter_action != 'onchange' ? 'class="input-append"' : ''; ?>>
+	<?php if (array_key_exists('all', $this->filters)) {
+		echo $this->filters['all']->element;
+
+	if ($this->filter_action != 'onchange') {?>
+
+		<input type="button" class="btn fabrik_filter_submit button" value="<?php echo FText::_('COM_FABRIK_GO');?>" name="filter" >
+
+	<?php
+	};?>
+
+	<?php };
+	?>
+	</div>
+	</li>
+</ul>
+<?php
+}
+?>
+</div>

--- a/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_buttons_btn_group.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_buttons_btn_group.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Bootstrap List Template - Buttons
+ *
+ * @package     Joomla
+ * @subpackage  Fabrik
+ * @copyright   Copyright (C) 2005-2016  Media A-Team, Inc. - All rights reserved.
+ * @license     GNU/GPL http://www.gnu.org/copyleft/gpl.html
+ * @since       3.1
+ */
+
+// No direct access
+defined('_JEXEC') or die('Restricted access');
+
+?>
+<div class="btn-group">
+	<?php if ($this->canGroupBy) :?>
+		<div class="btn-group">
+			<a href="#" class="btn dropdown-toggle groupBy" data-toggle="dropdown">
+				<?php echo FabrikHelperHTML::icon('icon-list-view', FText::_('COM_FABRIK_GROUP_BY'));?>
+			</a>
+			<ul class="dropdown-menu">
+				<?php foreach ($this->groupByHeadings as $url => $obj) {?>
+					<li><a data-groupby="<?php echo $obj->group_by?>" href="<?php echo $url?>"><?php echo $obj->label?></a></li>
+				<?php
+				}?>
+			</ul>
+		</div>
+	<?php endif ?>
+
+	<?php if ($this->showAdd) {?>
+		<a class="addbutton btn addRecord" href="<?php echo $this->addRecordLink;?>">
+			<?php echo FabrikHelperHTML::icon('icon-plus', $this->addLabel);?>
+		</a>
+	<?php }?>
+
+	<?php if ($this->showClearFilters) :?>
+		<a class="clearFilters btn" href="#">
+			<?php echo FabrikHelperHTML::icon('icon-refresh', FText::_('COM_FABRIK_CLEAR')); ?>
+		</a>
+	<?php endif ?>
+
+	<?php if ($this->showCSV) {?>
+		<a href="#" class="btn csvExportButton">
+			<?php echo FabrikHelperHTML::icon('icon-upload', FText::_('COM_FABRIK_EXPORT_TO_CSV')); ?>
+		</a>
+	<?php }?>
+
+	<?php if ($this->advancedSearch !== '') : ?>
+		<a href="<?php echo $this->advancedSearchURL?>" class="btn advanced-search-link">
+			<?php echo FabrikHelperHTML::icon('icon-search', FText::_('COM_FABRIK_ADVANCED_SEARCH')); ?>
+		</a>
+	<?php endif?>
+
+	<?php if ($this->showCSVImport) {?>
+		<a href="<?php echo $this->csvImportLink;?>" class="btn csvImportButton">
+			<?php echo FabrikHelperHTML::icon('icon-download', FText::_('COM_FABRIK_IMPORT_FROM_CSV')); ?>
+		</a>
+	<?php }?>
+
+	<?php if ($this->showRSS) {?>
+		<a href="<?php echo $this->rssLink;?>" class="btn feedButton">
+			<?php echo FabrikHelperHTML::image('feed.png', 'list', $this->tmpl);?>
+			<?php echo FText::_('COM_FABRIK_SUBSCRIBE_RSS');?>
+		</a>
+	<?php }
+	if ($this->showPDF) {?>
+			<a href="<?php echo $this->pdfLink;?>" class="btn pdfButton">
+				<?php echo FabrikHelperHTML::icon('icon-file', FText::_('COM_FABRIK_PDF')); ?>
+			</a>
+	<?php }?>
+
+
+</div>
+<p></p>

--- a/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_headings.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_headings.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Bootstrap List Template: Default Headings
+ *
+ * @package     Joomla
+ * @subpackage  Fabrik
+ * @copyright   Copyright (C) 2005-2016  Media A-Team, Inc. - All rights reserved.
+ * @license     GNU/GPL http://www.gnu.org/copyleft/gpl.html
+ * @since       3.0
+ */
+
+// No direct access
+defined('_JEXEC') or die('Restricted access');
+$btnLayout  = $this->getModel()->getLayout('fabrik-button');
+$layoutData = (object) array(
+	'class' => 'btn-info fabrik_filter_submit button',
+	'name' => 'filter',
+	'label' => FabrikHelperHTML::icon('icon-filter', FText::_('COM_FABRIK_GO'))
+);
+?>
+	<tr class="fabrik___heading">
+		<?php foreach ($this->headings as $key => $heading) :
+			$h = $this->headingClass[$key];
+			$style = empty($h['style']) ? '' : 'style="' . $h['style'] . '"'; ?>
+			<th class="heading <?php echo $h['class'] ?>" <?php echo $style ?>>
+				<span><?php echo $heading; ?></span>
+			</th>
+		<?php endforeach; ?>
+	</tr>
+
+<?php if (($this->filterMode === 3 || $this->filterMode === 4) && count($this->filters) <> 0) : ?>
+	<tr class="fabrikFilterContainer">
+		<?php foreach ($this->headings as $key => $heading) :
+			$h = $this->headingClass[$key];
+			$style = empty($h['style']) ? '' : 'style="' . $h['style'] . '"';
+			?>
+			<th class="<?php echo $h['class'] ?>" <?php echo $style ?>>
+				<?php
+				if (array_key_exists($key, $this->filters)) :
+
+					$filter = $this->filters[$key];
+					$required = $filter->required == 1 ? ' notempty' : '';
+					?>
+					<div class="listfilter<?php echo $required; ?> pull-left">
+						<?php echo $filter->element; ?>
+					</div>
+				<?php elseif ($key == 'fabrik_actions' && $this->filter_action != 'onchange') :
+					?>
+					<div style="text-align:center">
+						<?php echo $btnLayout->render($layoutData); ?>
+					</div>
+				<?php endif; ?>
+			</th>
+		<?php endforeach; ?>
+	</tr>
+<?php endif; ?>

--- a/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_pagination.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_pagination.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Fabrik List Template: Admin Bootstrap pagination
+ *
+ * @package		Joomla.Administrator
+ * @subpackage	Fabrik
+ * @copyright   Copyright (C) 2005-2016  Media A-Team, Inc. - All rights reserved.
+ * @license     GNU/GPL http://www.gnu.org/copyleft/gpl.html
+ */
+
+// No direct access
+defined('_JEXEC') or die('Restricted access');
+
+/**
+ * This is a file to add template specific chrome to pagination rendering.
+ *
+ * pagination_list_footer
+ *	Input variable $list is an array with offsets:
+ *		$list[prefix]		: string
+ *		$list[limit]		: int
+ *		$list[limitstart]	: int
+ *		$list[total]		: int
+ *		$list[limitfield]	: string
+ *		$list[pagescounter]	: string
+ *		$list[pageslinks]	: string
+ *
+ * pagination_list_render
+ *	Input variable $list is an array with offsets:
+ *		$list[all]
+ *			[data]		: string
+ *			[active]	: boolean
+ *		$list[start]
+ *			[data]		: string
+ *			[active]	: boolean
+ *		$list[previous]
+ *			[data]		: string
+ *			[active]	: boolean
+ *		$list[next]
+ *			[data]		: string
+ *			[active]	: boolean
+ *		$list[end]
+ *			[data]		: string
+ *			[active]	: boolean
+ *		$list[pages]
+ *			[{PAGE}][data]		: string
+ *			[{PAGE}][active]	: boolean
+ *
+ * pagination_item_active
+ *	Input variable $item is an object with fields:
+ *		$item->base	: integer
+ *		$item->prefix	: string
+ *		$item->link	: string
+ *		$item->text	: string
+ *
+ * pagination_item_inactive
+ *	Input variable $item is an object with fields:
+ *		$item->base	: integer
+ *		$item->prefix	: string
+ *		$item->link	: string
+ *		$item->text	: string
+ *
+ * This gives template designers ultimate control over how pagination is rendered.
+ *
+ * NOTE: If you override pagination_item_active OR pagination_item_inactive you MUST override them both
+ */
+/*
+function fabrik_pagination_list_footer($list)
+{
+	// Initialise variables.
+	$lang = JFactory::getLanguage();
+	$html = "<div class=\"container\"><div class=\"pagination\">\n";
+
+	$html .= "\n<div class=\"limit\">" . FText::_('JGLOBAL_DISPLAY_NUM') . $list['limitfield'] . "</div>";
+	$html .= $list['pageslinks'];
+	$html .= "\n<div class=\"limit\">" . $list['pagescounter'] . "</div>";
+
+	$html .= "\n<input type=\"hidden\" name=\"" . $list['prefix'] . "limitstart\" value=\"" . $list['limitstart'] . "\" />";
+	$html .= "\n</div></div>";
+
+	return $html;
+}
+ */
+
+/* Commented out because /components/com_fabrik/helpers/pagination.php does not call this routine
+function fabrik_pagination_list_footer($list, $paginator)
+{
+	// Initialize variables
+	$html = array();
+	$html[] = '<div class="list-footer">';
+	$limitLabel = $paginator->showDisplayNum ? FText::_('COM_FABRIK_DISPLAY_NUM') : '';
+	$html[] = '<div class="limit input-prepend"><button class="add-on">' . $limitLabel  . '</button>' . $list['limitfield'] . '</div>';
+	$html[] = $list['pageslinks'];
+	$html[] = '<div class="counter">' . $list['pagescounter'] . '</div>';
+	$html[] = '<input type="hidden" name="limitstart' . $paginator->_id . '" id="limitstart' . $paginator->_id . '" value="' . $list['limitstart'] . '" />';
+	$html[] = '</div>';
+	return implode("\n", $html);
+}
+*/
+
+if (!function_exists('fabrik_pagination_item_active'))
+{
+	function fabrik_pagination_item_active(&$item, $listid)
+	{
+		switch ($item->key)
+		{
+			case 'previous':
+				$rel = 'rel="prev" ';
+				break;
+			case 'next':
+				$rel = 'rel="next" ';
+				break;
+			default:
+				$rel = '';
+		}
+		return '<a ' . $rel . 'title="' . $item->text . '" href="' . $item->link . '">' . $item->text . '</a>';
+	}
+}
+
+if (!function_exists('fabrik_pagination_item_inactive'))
+{
+	function fabrik_pagination_item_inactive(&$item)
+	{
+		return '<a href="#">' . $item->text . '</a>';
+	}
+}

--- a/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_row.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_row.php
@@ -16,24 +16,29 @@ $tr = $this->_row->id;
 <tr id="<?php echo $tr;?>" class="<?php echo $this->_row->class;?>">
 	<?php foreach ($this->headings as $heading => $label) {
 		$v = $this->_row->data->$heading;
+		$pkField = empty($this->pkFields->$heading->name) ? '__pk_val' : $this->pkFields->$heading->name;
+		$pkValue = empty($this->_row->data->$pkField) ? 0 : $this->_row->data->$pkField;
 		$showCell = $this->rowSpanData[$this->_row->cursor][$heading]['showCell'];
 		$rowspan = '';
 		if ($showCell == true)
 		{
-			$rowspan = isset($this->rowSpans) ? $this->rowSpans[$heading][$tr][$v] : 'Debug: no rowspan';
-			$rowspan = count($rowspan);			
+			$rowspans = isset($this->rowSpans) ? $this->rowSpans[$heading][$tr][$pkValue] : array();
+			$rowspan = 'rowspan="' . count($rowspans) . '"';			
 		}
 		else
 		{
 			$rowspan = '';
 		}
-			$style = empty($this->cellClass[$heading]['style']) ? '' : 'style="'.$this->cellClass[$heading]['style'].'"';
+		
+		$style = empty($this->cellClass[$heading]['style']) ? '' : 'style="'.$this->cellClass[$heading]['style'].'"';
+		
+		if ($showCell)
+		{
 			?>
-			<td class="<?php echo $this->cellClass[$heading]['class']?>" <?php //echo $rowspan;?><?php echo $style?>>
-				<?php echo isset($this->_row->data) ? $v . ' + ' . var_dump($this->rowSpanData[$this->_row->cursor][$heading]['showCell']) . ' + ' . $rowspan  : '';?>
+			<td class="<?php echo $this->cellClass[$heading]['class']?>" <?php echo $rowspan;?><?php echo $style?>>
+				<?php echo isset($this->_row->data) ? $v  : '';?>
 			</td>
 		<?php 
-		
-	}
+		}	}
 	?>
 </tr>

--- a/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_row.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_row.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Fabrik List Template: Admin Row
+ *
+ * @package     Joomla
+ * @subpackage  Fabrik
+ * @copyright   Copyright (C) 2005-2016  Media A-Team, Inc. - All rights reserved.
+ * @license     GNU/GPL http://www.gnu.org/copyleft/gpl.html
+ */
+
+// No direct access
+defined('_JEXEC') or die('Restricted access');
+$tr = $this->_row->id;
+
+?>
+<tr id="<?php echo $tr;?>" class="<?php echo $this->_row->class;?>">
+	<?php foreach ($this->headings as $heading => $label) {
+		$v = $this->_row->data->$heading;
+		$showCell = $this->rowSpanData[$this->_row->cursor][$heading]['showCell'];
+		$rowspan = '';
+		if ($showCell == true)
+		{
+			$rowspan = isset($this->rowSpans) ? $this->rowSpans[$heading][$tr][$v] : 'Debug: no rowspan';
+			$rowspan = count($rowspan);			
+		}
+		else
+		{
+			$rowspan = '';
+		}
+			$style = empty($this->cellClass[$heading]['style']) ? '' : 'style="'.$this->cellClass[$heading]['style'].'"';
+			?>
+			<td class="<?php echo $this->cellClass[$heading]['class']?>" <?php //echo $rowspan;?><?php echo $style?>>
+				<?php echo isset($this->_row->data) ? $v . ' + ' . var_dump($this->rowSpanData[$this->_row->cursor][$heading]['showCell']) . ' + ' . $rowspan  : '';?>
+			</td>
+		<?php 
+		
+	}
+	?>
+</tr>

--- a/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_tabs.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_tabs.php
@@ -1,0 +1,14 @@
+<?php
+
+// No direct access
+defined('_JEXEC') or die('Restricted access');
+
+if (!empty($this->tabs)) :
+?>
+<div>
+	<?php
+	echo $this->getModel()->getLayout('fabrik-tabs')->render((object) array('tabs' => $this->tabs));
+	?>
+</div>
+<?php
+endif; ?>

--- a/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_togglecols.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/default_togglecols.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Bootstrap List Template - Toggle columns widget
+ *
+ * @package     Joomla
+ * @subpackage  Fabrik
+ * @copyright   Copyright (C) 2005-2016  Media A-Team, Inc. - All rights reserved.
+ * @license     GNU/GPL http://www.gnu.org/copyleft/gpl.html
+ * @since       3.1
+ */
+
+// No direct access
+defined('_JEXEC') or die('Restricted access');
+?>
+<li class="dropdown togglecols">
+	<a href="#" class="dropdown-toggle" data-toggle="dropdown">
+		<?php echo FabrikHelperHTML::icon('icon-eye-open', FText::_('COM_FABRIK_TOGGLE')); ?>
+		<b class="caret"></b>
+	</a>
+	<ul class="dropdown-menu">
+	<?php
+	$groups = array();
+
+	foreach ($this->toggleCols as $group) :
+		?>
+		<li>
+			<a data-toggle-group="<?php echo $group['name']?>" data-toggle-state="open">
+				<?php echo FabrikHelperHTML::icon('icon-eye-open'); ?>
+				<strong><?php echo $group['name'];?></strong>
+			</a>
+		</li>
+		<?php
+		foreach ($group['elements'] as $element => $label) :
+		?>
+		<li>
+			<a data-toggle-col="<?php echo $element?>" data-toggle-parent-group="<?php echo $group['name']?>" data-toggle-state="open">
+				<?php echo FabrikHelperHTML::icon('icon-eye-open', $label); ?>
+			</a>
+		</li>
+		<?php
+		endforeach;
+
+	endforeach;
+
+	?>
+	</ul>
+</li>

--- a/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/template_css.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap_mergerows/template_css.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Fabrik List Template: Bootstrap
+ *
+ * @package     Joomla
+ * @subpackage  Fabrik
+ * @copyright   Copyright (C) 2005-2016  Media A-Team, Inc. - All rights reserved.
+ * @license     GNU/GPL http://www.gnu.org/copyleft/gpl.html
+ */
+
+header('Content-type: text/css');
+$c = $_REQUEST['c'];
+$buttonCount = (int) $_REQUEST['buttoncount'];
+$buttonTotal = $buttonCount === 0 ? '100%' : 30 * $buttonCount ."px";
+echo "
+
+.fabrikDataContainer {
+	clear:both;
+	/*
+		dont use this as it stops dropdowns from showing correctly
+		overflow: auto;*/
+}
+
+.fabrikDataContainer .pagination a{
+	float: left;
+}
+
+ul.fabrikRepeatData {
+	list-style: none;
+	list-style-position:inside;
+	margin: 0;
+	padding-left: 0;
+}
+.fabrikRepeatData > li {
+	white-space: nowrap;
+	max-width:350px;
+	overflow:hidden;
+	text-overflow: ellipsis;
+}
+td.repeat-merge div, td.repeat-reduce div,
+td.repeat-merge i, td.repeat-reduce i {
+padding: 5px !important;
+}
+
+.nav li {
+list-style: none;
+}
+
+.filtertable_horiz {
+	display: inline-block;
+	vertical-align: top;
+}
+
+.fabrikListFilterCheckbox {
+	text-align: left;
+}
+
+.fabrikDateListFilterRange {
+	text-align: left;
+	display: inline-block;
+}
+";?>

--- a/components/com_fabrik/views/list/view.base.php
+++ b/components/com_fabrik/views/list/view.base.php
@@ -588,8 +588,141 @@ class FabrikViewListBase extends FabrikView
 
 		$this->buttons();
 		$this->pluginTopButtons = $model->getPluginTopButtons();
+		$this->rowSpanData = $this->rowSpanData();
+		$this->rowSpans = $this->rowSpanData['elements'];
+		
+		// Jaanuse täienduse algus
+		//$rowspan = $this->rowSpanVals();
+/*
+		echo '<pre>';
+		echo 'ELAGU KOOD :D<br>';
+		var_dump($this->rowSpanData);
+		echo '</pre>';
+*/
+		
 	}
 
+	public function rowSpanData()
+	{
+		$c = array();
+		
+		foreach ($this->rows as $group)	
+		{
+/*					
+			foreach ($group as $this->_row)
+			{
+				echo '<pre>';
+				echo 'SEE RIDA';
+				var_dump($this->_row);
+				echo '</pre>';
+				$r = $this->_row->id;
+				$c[$r][] = $this->_row->cursor;
+				$c['rownum'] = $this->_row->cursor;
+			}
+*/			
+			foreach ($c as $r => $rid)
+			{
+				$c['rowcount'][$r] = count($c[$r]);
+			}
+			
+			foreach ($this->headings as $heading => $label) 
+			{
+				foreach ($group as $this->_row)
+				{
+					$r = $this->_row->id;
+					$d = $this->_row->data->$heading;
+					$c['elements'][$heading][$r][$d][] = $this->_row->cursor;
+					//$cnumber = count($c['elements'][$heading][$r][$d]);
+					$crs = $c['elements'][$heading][$r][$d][0];
+					
+					$c[$this->_row->cursor][$heading]['showCell'] = false;
+					
+					if ($crs == $this->_row->cursor)
+					{
+						$c[$this->_row->cursor][$heading]['showCell'] = true;
+						// $cnumber = max(array_keys($c[$heading][$r][$d])) + 1;
+						$c[$this->_row->cursor][$heading]['rowspan'] = 'rowspan="' . $cnumber . '"';
+					}
+					
+				}
+				
+			}
+/*			
+			foreach ($c as $heading => $rid)
+			{
+				foreach ((array) $rid as $r => $rd)
+				{
+					foreach ((array) $rd as $d => $v)
+					{
+						$c['datacount'][$heading][$r][$d] = count($c[$heading][$r][$d]);
+						$cnumber = $c['datacount'][$heading][$r][$d];
+
+						if ($c[$heading][$r][$d][0])
+						{
+							$c['showCell'][$heading][$r][$d] = true;
+							$c['rowspan'][$heading][$r][$d] = 'rowspan="' . $cnumber . '"';
+							
+						}
+					}
+				}
+			}
+*/		
+		}
+
+		$rowSpanValues = $c['elements'];
+		echo '<pre>';
+		echo 'KAS SAAME KORDUSED KÄTTE :D<br>';
+		var_dump($c['elements']);
+		echo '</pre>';
+		
+		return $c;
+	}
+
+/*
+	public function rowSpanVals()
+	{
+		foreach ($this->rows as $group)	
+		{
+			$d = array();
+			//$rowspan = array();
+			//$cnt = array();
+			foreach ($this->headings as $heading => $label) 
+			{
+				$i = 0;
+				$d[$heading]['showCell'] = false;
+				$d[$heading]['amount'] = null;
+				$cnt_r = count($d[$heading][$v][$tr]);
+
+				foreach ($group as $this->_row)
+				{
+					$tr = $this->_row->id;
+					$v = $this->_row->data->$heading;
+					$d[$heading][$v][$tr][$i] = $v;	
+					if ($this->_row->id == $tr)
+					{
+						$this->_row->rownum = $i;
+					}
+					if ($i == min(array_keys($d[$heading][$v][$tr])))
+					{
+						$d[$heading]['showCell'] = true;
+						$d[$heading]['amount'] = 'rowspan="' . $cnt_r . '" ';
+					}
+					
+					$i++;
+				}
+
+
+				
+				
+			}
+			
+			return $d;
+		}
+		
+	// Jaanuse täienduse lõpp
+	}
+	*/
+	
 	/**
 	 * Model check for publish/access
 	 *

--- a/components/com_fabrik/views/list/view.base.php
+++ b/components/com_fabrik/views/list/view.base.php
@@ -641,7 +641,7 @@ class FabrikViewListBase extends FabrikView
 					{
 						$c[$this->_row->cursor][$heading]['showCell'] = true;
 						// $cnumber = max(array_keys($c[$heading][$r][$d])) + 1;
-						$c[$this->_row->cursor][$heading]['rowspan'] = 'rowspan="' . $cnumber . '"';
+						// $c[$this->_row->cursor][$heading]['rowspan'] = 'rowspan="' . $cnumber . '"';
 					}
 					
 				}
@@ -848,11 +848,11 @@ class FabrikViewListBase extends FabrikView
 
 		$buttonProperties['title'] = '<span>' . FText::_('COM_FABRIK_GROUP_BY') . '</span>';
 		$buttonProperties['alt']   = FText::_('COM_FABRIK_GROUP_BY');
-		$this->buttons->groupby    = FabrikHelperHTML::image('list-view', 'list', $this->tmpl, $buttonProperties);
+		$this->buttons->groupby    = FabrikHelperHTML::image('group_by.png', 'list', $this->tmpl, $buttonProperties);
 
 		unset($buttonProperties['title']);
 		$buttonProperties['alt'] = FText::_('COM_FABRIK_FILTER');
-		$this->buttons->filter   = FabrikHelperHTML::image('filter', 'list', $this->tmpl, $buttonProperties);
+		$this->buttons->filter   = FabrikHelperHTML::image('filter.png', 'list', $this->tmpl, $buttonProperties);
 
 		$addLabel                  = $model->addLabel();
 		$buttonProperties['title'] = '<span>' . $addLabel . '</span>';


### PR DESCRIPTION
This PR is made ATM in testing and further developing purposes, not for immediate merge. 

When we display a list with joins "each row separately" then also main data and other "nonrepeated or less repeated data is duplicated in list view and when we have lot of data then it could be very difficult to read this. 

When this list is displayed as "merge & reduce" all joined repeated data is reduced to a single table row <tr>. Usually looks well but there can be difficult to see relationship between data in different columns even within the same group. 

The best possible way could be orgiginal (and less repeated data) to be merged down using html rowspan. The data is not duplicated, but all data and relationsips between them can be clearly seen as every data unit is in it own table cell (<td>). 

The code is in its current state working with "each row separately" and temporary new template. With multple repeated joins it works ATM fully correctly if the joins are in chain (table1->table2->table3...). 2 or more repeated joins with single parent (usually main table pk). could mess completely up the rows as each row tries to be in relations with others. 
Correct ordering of data in repeat groups in this case is the most important "todo" for now. 
