### PR TITLE
Update list.php

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -11662,11 +11662,7 @@ class FabrikFEModelList extends JModelForm
 			$row['fabrik_copy_from_table'] = '1';
 
             		$defaultcols = $this->getParams()->get('list_copy_default_columns', '');
-            		foreach($defaultcols as $key => $value){
-                		$def = $value;
-                		break;
-            		}
-            		if(!empty($def)) $row['list_copy_default_columns'] = $def;
+            		if(!empty($defaultcols)) $row['list_copy_default_columns'] = $defaultcols;
 			
 			$formModel->formData = $row;
 

--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -11660,6 +11660,14 @@ class FabrikFEModelList extends JModelForm
 			$formModel->copyFromRaw($row, true);
 			$row['Copy'] = '1';
 			$row['fabrik_copy_from_table'] = '1';
+
+            		$defaultcols = $this->getParams()->get('list_copy_default_columns', '');
+            		foreach($defaultcols as $key => $value){
+                		$def = $value;
+                		break;
+            		}
+            		$row['list_copy_default_columns'] = $def;
+			
 			$formModel->formData = $row;
 
 			if (!$formModel->process())

--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -11666,7 +11666,7 @@ class FabrikFEModelList extends JModelForm
                 		$def = $value;
                 		break;
             		}
-            		$row['list_copy_default_columns'] = $def;
+            		if(!empty($def)) $row['list_copy_default_columns'] = $def;
 			
 			$formModel->formData = $row;
 


### PR DESCRIPTION
Changes to list.php, element.php and xml/language files to allow configuration of columns that should be reset to default when copied via list copy plugin . 