### PR TITLE
Update fabrik-element-yesno-details.php

### DIFF
--- a/plugins/fabrik_element/yesno/layouts/fabrik-element-yesno-details.php
+++ b/plugins/fabrik_element/yesno/layouts/fabrik-element-yesno-details.php
@@ -20,25 +20,30 @@ $format = $d->format;
 $j3 = FabrikWorker::j3();
 
 $opts = array();
-$properties = array();
+$yes_label = (empty($d->yes_label)) ? FText::_('JYES') : FText::_($d->yes_label) ;
+$no_label = (empty($d->no_label)) ? FText::_('JNO') : FText::_($d->no_label) ;
+$show_label = (empty($d->show_label)) ? '0' : $d->show_label;
+$yes_image = (empty($d->yes_image)) ? 'checkmark' : $d->yes_image ;
+$no_image = (empty($d->no_image)) ? 'remove' : $d->no_image ;
 
-if ($d->format == 'pdf') :
+// if period . in image name assume it is a file
+if ($d->format == 'pdf' || strpos($yes_image,'.')>0 ) :
 	$opts['forceImage'] = true;
 	FabrikHelperHTML::addPath(COM_FABRIK_BASE . 'plugins/fabrik_element/yesno/images/', 'image', 'list', false);
 endif;
 
-$yes_image = ($d->yes_image == '') ? 'checkmark.png' : $d->yes_image ;
-$no_image = ($d->no_image == '') ? 'remove.png' : $d->no_image ;
 if(!empty($d->image_height)) $properties['style'] = FText::_('height:'.$d->image_height.'px!important');
-
+ 
 if ($data == '1') :
 	$icon = $j3 && $format != 'pdf' ? $yes_image : '1.png';
-	$properties['alt'] = FText::_('JYES');
-
-	echo FabrikHelperHTML::image($icon, 'list', $tmpl, $properties, false, $opts);
+	$properties['alt'] = $yes_label;
 else :
-	$icon = $j3 && $format != 'pdf' ? $no_image : '0.png'; 
-	$properties['alt'] = FText::_('JNO');
-
-	echo FabrikHelperHTML::image($icon, 'list', $tmpl, $properties, false, $opts);
+	$icon = $j3 && $format != 'pdf' ? $no_image : '0.png';
+    $properties['alt'] = $no_label;
 endif;
+//error_log('fabrik-element-yesno-details.php - '.FabrikHelperHTML::image($icon, 'details', $tmpl, $properties, false, $opts));
+if($show_label) :
+    echo ((int)$data == 0) ? $no_label : $yes_label ;
+else :
+    echo FabrikHelperHTML::image($icon, 'details', $tmpl, $properties, false, $opts);
+endif; 

--- a/plugins/fabrik_element/yesno/layouts/fabrik-element-yesno-details.php
+++ b/plugins/fabrik_element/yesno/layouts/fabrik-element-yesno-details.php
@@ -34,6 +34,15 @@ endif;
 
 if(!empty($d->image_height)) $properties['style'] = FText::_('height:'.$d->image_height.'px!important');
  
+/* (Bauer notes: Added because FabrikHelperHTML::image will unset properties['alt'] (why I don't know) 
+ *  which makes it difficult to identify the value of the element in list or detail view.
+ *  Not sure which of these, or both should be used - I vote for added class.)
+ */
+if($j3) {
+    $properties['class'] = 'yn_val'.$data;
+	$properties['title'] = ($data == '0') ? FText::_('JNO') : FText::_('JYES');
+}
+
 if ($data == '1') :
 	$icon = $j3 && $format != 'pdf' ? $yes_image : '1.png';
 	$properties['alt'] = $yes_label;

--- a/plugins/fabrik_element/yesno/layouts/fabrik-element-yesno-details.php
+++ b/plugins/fabrik_element/yesno/layouts/fabrik-element-yesno-details.php
@@ -27,13 +27,17 @@ if ($d->format == 'pdf') :
 	FabrikHelperHTML::addPath(COM_FABRIK_BASE . 'plugins/fabrik_element/yesno/images/', 'image', 'list', false);
 endif;
 
+$yes_image = ($d->yes_image == '') ? 'checkmark.png' : $d->yes_image ;
+$no_image = ($d->no_image == '') ? 'remove.png' : $d->no_image ;
+if(!empty($d->image_height)) $properties['style'] = FText::_('height:'.$d->image_height.'px!important');
+
 if ($data == '1') :
-	$icon = $j3 && $format != 'pdf' ? 'checkmark' : '1.png';
+	$icon = $j3 && $format != 'pdf' ? $yes_image : '1.png';
 	$properties['alt'] = FText::_('JYES');
 
 	echo FabrikHelperHTML::image($icon, 'list', $tmpl, $properties, false, $opts);
 else :
-	$icon = $j3 && $format != 'pdf' ? 'remove' : '0.png';
+	$icon = $j3 && $format != 'pdf' ? $no_image : '0.png'; 
 	$properties['alt'] = FText::_('JNO');
 
 	echo FabrikHelperHTML::image($icon, 'list', $tmpl, $properties, false, $opts);


### PR DESCRIPTION
With these changes, this element should be called (or thought of as) the 'Toggle' element rather than YesNo - but I suppose YesNo is fine for historical reasons. 

These updates to the YesNo element plugin allow you to (optionally) add 4 new configuration options to  'YesNo' elements.  
In details and list view:
1. Specify custom 'Yes' and 'No' images as an icon- prefix name or image file (in plugin's images folder) 
2. Specify the custom images height
3. Option to show custom label instead of an icon- or image file in details and list view
And in form view: 
4. Custom labels for 'Yes' and 'No' radio button text

Just hoping to add some life and versatility to this element so it more owns up to its potential. With these changes this element would be perfect to use anytime where you need to compare or select from 2 different possibilities or opposing conditions - e.g. 2 sports teams (with 2 logos) or 2 political candidates (with 2 portraits) - or more simply - Locked/Unlocked, Up/Down, Left/Right, Black/White, etc.

I've been running this version for a few days and so far so good. If anyone wants to just copy these 5 files to help test this, I'd sure appreciate it. (Be sure to zip your plugins/fabrik_element/yesno folder to have an archive of code before these changes were applied.)