### PR TITLE
Allow form plugin to reference the origin rowid in the URL

### DIFF
--- a/plugins/content/fabrik/fabrik.php
+++ b/plugins/content/fabrik/fabrik.php
@@ -392,6 +392,9 @@ class PlgContentFabrik extends JPlugin
 				// Set row id for things like user element
 				$origRowId = $input->get('rowid');
 				$input->set('rowid', $rowId);
+				
+				// Allow plugin to reference the origin rowid in the URL
+				$input->set('origRowId', $origRowId);
 
 				// Set detail view for things like youtube element
 				$origView = $input->get('view');
@@ -420,6 +423,7 @@ class PlgContentFabrik extends JPlugin
 
 				$input->set('rowid', $origRowId);
 				$input->set('view', $origView);
+				$input->set('origRowId', '');
 				$this->resetRequest();
 			}
 


### PR DESCRIPTION
seems that if you have a form rendered as a plugin, you can not access the rowid contained within the url.
This merge request assigns the original rowid to 'origRowId' and resets it to '' after the form is rendered