### PR TITLE
re-introduce autocomplete_rows

### DIFF
--- a/administrator/components/com_fabrik/models/forms/element.xml
+++ b/administrator/components/com_fabrik/models/forms/element.xml
@@ -151,6 +151,14 @@
 				description="COM_FABRIK_FIELD_FILTER_LENGTH_DESC"
 				label="COM_FABRIK_FIELD_FILTER_LENGTH_LABEL" />
 
+			<field name="autocomplete_rows"
+				type="text"
+				size="3"
+				default="10"
+				class="input-mini"
+				description="PLG_ELEMENT_DBJOIN_AUTOCOMPLETE_ROWS_DESC"
+				label="PLG_ELEMENT_DBJOIN_AUTOCOMPLETE_ROWS_LABEL" />
+
 			<field name="filter_access"
 				type="accesslevel"
 				default="1"

--- a/components/com_fabrik/helpers/html.php
+++ b/components/com_fabrik/helpers/html.php
@@ -2028,6 +2028,7 @@ EOD;
 		$json->formRef   = FArrayHelper::getValue($opts, 'formRef', 'form_' . $formId);
 		$json->container = FArrayHelper::getValue($opts, 'container', 'fabrikElementContainer');
 		$json->menuclass = FArrayHelper::getValue($opts, 'menuclass', 'auto-complete-container');
+		$json->max = FArrayHelper::getValue($opts, 'autocomplete_rows', 10);
 
 		return $json;
 	}

--- a/components/com_fabrik/models/element.php
+++ b/components/com_fabrik/models/element.php
@@ -3581,6 +3581,10 @@ class PlgFabrik_Element extends FabrikPlugin
 
 		$element = $this->getElement();
 		$formId  = $this->getFormModel()->getId();
+
+		$params = $registry = new Registry($element->params);
+		$opts['autocomplete_rows'] = $params->get('autocomplete_rows', 10);
+
 		FabrikHelperHTML::autoComplete($selector, $element->id, $formId, $element->plugin, $opts);
 
 		return $return;


### PR DESCRIPTION
The autocomplete_rows setting was introduced with #859 - and it seems that since then, it has been removed (by accident?)

If this was by accident, this commit reintroduces it for element list filters.