### PR TITLE
Update fabrik-element-databasejoin-form-description.php

### DIFF
--- a/plugins/fabrik_element/databasejoin/layouts/fabrik-element-databasejoin-form-description.php
+++ b/plugins/fabrik_element/databasejoin/layouts/fabrik-element-databasejoin-form-description.php
@@ -17,7 +17,7 @@ $d = $displayData;
 			$display = $opt->value == $d->default ? '' : 'style="display: none" ';
 			//$c = $d->showPleaseSelect ? $i + 1 : $i;
 		?>
-			<div <?php echo $display ;?> class="notice description-<?php echo  $i; ?>">
+			<div <?php echo $display ;?> class="notice description-<?php echo $opt->value; ?>">
 				<?php echo $opt->description; ?>
 			</div>
 		<?php


### PR DESCRIPTION
Use 'echo $opt->value;' (pk value) instead of 'echo $i;' (index sequence) in description- classname. Fixes bug where, if list gets filtered dynamically via WHERE condition, the index will not be in original sequence and therefor showed wrong description for selected option.