### PR TITLE
Remove double quotes that cause HTML warning

### DIFF
--- a/components/com_fabrik/views/form/tmpl/bootstrap/default_actions.php
+++ b/components/com_fabrik/views/form/tmpl/bootstrap/default_actions.php
@@ -28,7 +28,7 @@ if ($this->hasActions) : ?>
 			</div>
 		<?php endif; ?>
 		<?php if ($form->customButtons): ?>
-			<div class="fabrikCustomButtons <?php echo FabrikHelperHTML::getGridSpan(2); ?>"">
+			<div class="fabrikCustomButtons <?php echo FabrikHelperHTML::getGridSpan(2); ?>">
 				<div class="btn-group">
 					<?php echo $form->customButtons; ?>
 				</div>

--- a/components/com_fabrik/views/form/tmpl/bootstrap_tabs/default_actions.php
+++ b/components/com_fabrik/views/form/tmpl/bootstrap_tabs/default_actions.php
@@ -24,7 +24,7 @@ if ($this->hasActions) : ?>
 			?>
 		</div>
 		<?php if ($form->customButtons): ?>
-			<div class="fabrikCustomButtons <?php echo FabrikHelperHTML::getGridSpan(2); ?>"">
+			<div class="fabrikCustomButtons <?php echo FabrikHelperHTML::getGridSpan(2); ?>">
 				<div class="btn-group">
 				<?php echo $form->customButtons; ?>
 				</div>


### PR DESCRIPTION
Remove a couple of double quotes to avoid an HTML warning