### PR TITLE
Use jQuery .closest() instead Element.Closest()

### DIFF
--- a/media/com_fabrik/js/form.js
+++ b/media/com_fabrik/js/form.js
@@ -1365,7 +1365,7 @@ define(['jquery', 'fab/encoder', 'fab/fabrik', 'lib/debounce/jquery.ba-throttle-
                 hiddenElements = [];
                 // insert hidden element of hidden elements (!) used by validation code for "skip if hidden" option
                 jQuery.each(this.formElements, function (id, el) {
-                   if (el.element && jQuery(el.element.closest('.fabrikHide')).length !== 0) {
+                   if (el.element && jQuery(el.element).closest('.fabrikHide').length !== 0) {  
                        hiddenElements.push(id);
                    }
                 });


### PR DESCRIPTION
Pure JS Element.Closest() cause a problem with form validation and form sending with unsupported browsers like all IE versions.
Issue #1883 