### PR TITLE
don't create HTML link in list if element is empty

### DIFF
--- a/components/com_fabrik/layouts/element/fabrik-element-custom-link.php
+++ b/components/com_fabrik/layouts/element/fabrik-element-custom-link.php
@@ -13,6 +13,7 @@
 defined('_JEXEC') or die('Restricted access');
 $d = $displayData;
 
+if ($d->data != ''):
 ?>
 <a data-loadmethod="<?php echo $d->loadMethod;?>"
 	class="<?php echo $d->class; ?>"
@@ -27,3 +28,4 @@ $d = $displayData;
 >
 <?php echo $d->data; ?>
 </a>
+<?php endif ?>


### PR DESCRIPTION
The "sighted" user won't see anything to click on. But links without link text are confusing for accessibility reasons.

Is there any impact with JS expecting <a... ?