### PR TITLE
Add list group headers

### DIFF
--- a/administrator/components/com_fabrik/language/en-GB/en-GB.com_fabrik.ini
+++ b/administrator/components/com_fabrik/language/en-GB/en-GB.com_fabrik.ini
@@ -1289,6 +1289,8 @@ COM_FABRIK_SHOW_RELATED_ADD_DESC="Setting this to Yes will always show an Add li
 
 COM_FABRIK_BOOTSTRAP_LIST_OPTIONS="Bootstrap list classes"
 COM_FABRIK_ERR_ONE_GROUP_MUST_BE_SELECTED="At least one group must be selected"
+COM_FABRIK_FIELD_BOOSTRAP_LIST_GROUPS_HEADER_DESC="Bootstrap only - Additional list header showing groups."
+COM_FABRIK_FIELD_BOOSTRAP_LIST_GROUPS_HEADER_LABEL="Group Header"
 COM_FABRIK_FIELD_BOOSTRAP_LIST_CONDENSED_CLASS_DESC="Bootstrap only - Makes tables more compact by cutting cell padding in half."
 COM_FABRIK_FIELD_BOOSTRAP_LIST_CONDENSED_CLASS_LABEL="Condensed"
 COM_FABRIK_FIELD_BOOSTRAP_LIST_STRIPPED_CLASS_DESC="Bootstrap only - Adds zebra-striping to any table row within the &lt;tbody&gt; via the :nth-child CSS selector (not available in IE7-IE8)."

--- a/administrator/components/com_fabrik/models/forms/list.xml
+++ b/administrator/components/com_fabrik/models/forms/list.xml
@@ -1044,6 +1044,17 @@
 
 		<fieldset name="layout-bootstrap">
 
+			<field name="bootstrap_groups_header"
+			       type="radio"
+			       class="btn-group"
+			       default="0"
+			       label="COM_FABRIK_FIELD_BOOSTRAP_LIST_GROUPS_HEADER_LABEL"
+			       description="COM_FABRIK_FIELD_BOOSTRAP_LIST_GROUPS_HEADER_DESC"
+			>
+				<option value="0">JNO</option>
+				<option value="1">JYES</option>
+			</field>
+
 			<field name="bootstrap_stripped_class"
 			       type="radio"
 			       class="btn-group"

--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -11151,6 +11151,11 @@ class FabrikFEModelList extends JModelForm
 		$params = $this->getParams();
 		$class = array('table');
 
+		if ($params->get('bootstrap_groups_header', true))
+		{
+			$class[] = 'table-group-header';
+		}
+
 		if ($params->get('bootstrap_stripped_class', true))
 		{
 			$class[] = 'table-striped';

--- a/components/com_fabrik/views/list/tmpl/bootstrap/default_headings.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap/default_headings.php
@@ -17,7 +17,48 @@ $layoutData = (object) array(
 	'name' => 'filter',
 	'label' => FabrikHelperHTML::icon('icon-filter', FText::_('COM_FABRIK_GO'))
 );
-?>
+$groupHeaders = in_array("table-group-header", explode(" ", $this->table->class));
+
+if ($groupHeaders && count($this->groupheadings) > 1) : ?>
+	<tr class="fabrik___heading">
+		<?php 
+		$currentGrp = NULL;
+		$currentStyle = NULL;
+		$grpCount = 0;
+		foreach ($this->headings as $key => $heading) :
+			$grp = "";
+			$style = $this->headingClass[$key]['style'];
+			foreach ($this->toggleCols as $cols) :
+				if (array_key_exists($key, $cols["elements"])) :
+					$grp = $cols["name"];
+					break;
+				endif;
+			endforeach;
+			if ($grp !== $currentGrp || $style !== $currentStyle) :
+				if ($grpCount == 1) : ?>
+					<th class="heading fabrik_groupcell" <?php if (!empty($currentStyle)) echo 'style="' . $currentStyle . '"' ?>></th>
+				<?php elseif ($grpCount > 1) : ?>
+					<th colspan="<?php echo $grpCount ?>" class="heading fabrik_groupcell" <?php if (!empty($currentStyle)) echo 'style="' . $currentStyle . '"' ?>>
+						<span><?php echo $currentGrp; ?></span>
+					</th>
+				<?php endif;
+				$grpCount = 1;
+				$currentGrp = $grp;
+				$currentStyle = $style;
+			else :
+				$grpCount++;
+			endif;
+		endforeach; 
+		if ($grpCount == 1) : ?>
+			<th class="heading fabrik_groupcell" <?php if (!empty($currentStyle)) echo 'style="' . $currentStyle . '"' ?>></th>
+		<?php elseif ($grpCount > 1) : ?>
+			<th colspan="<?php echo $grpCount ?>" class="heading fabrik_groupcell" <?php if (!empty($currentStyle)) echo 'style="' . $currentStyle . '"' ?>>
+				<span><?php echo $currentGrp; ?></span>
+			</th>
+		<?php endif; ?>
+	</tr>
+<?php endif; ?>
+
 	<tr class="fabrik___heading">
 		<?php foreach ($this->headings as $key => $heading) :
 			$h = $this->headingClass[$key];

--- a/components/com_fabrik/views/list/tmpl/bootstrap/default_headings.php
+++ b/components/com_fabrik/views/list/tmpl/bootstrap/default_headings.php
@@ -19,7 +19,7 @@ $layoutData = (object) array(
 );
 $groupHeaders = in_array("table-group-header", explode(" ", $this->table->class));
 
-if ($groupHeaders && count($this->groupheadings) > 1) : ?>
+if ($groupHeaders && count($this->groupheadings) > 1 && max($this->groupheadings) > 1) : ?>
 	<tr class="fabrik___heading">
 		<?php 
 		$currentGrp = NULL;


### PR DESCRIPTION
This PR adds new functionality to the bootstrap list template that adds an additional header row for lists that consist of more than one group at least one of which has mroe than one column.