### PR TITLE
Add all free plugins to Fabrik package

### DIFF
--- a/fabrik_build/build-config.js
+++ b/fabrik_build/build-config.js
@@ -37,6 +37,7 @@ module.exports = {
         'plg_fabrik_list_copy_{version}.zip',
         'plg_fabrik_list_php_{version}.zip',
         'plg_fabrik_validationrule_isgreaterorlessthan_{version}.zip',
+        'plg_fabrik_validationrule_isuniquevalue_{version}.zip',
         'plg_fabrik_validationrule_notempty_{version}.zip',
         'plg_fabrik_validationrule_php_{version}.zip',
         'plg_fabrik_validationrule_regex_{version}.zip',


### PR DESCRIPTION
Adding all free plugins to the fabrik package for several reasons:

1. Many people won't know they exist and can be added.
2. Finding individual packages on fabrikar.com, then download, uploading and installing them is a PITA.
3. Manually installed plugins are not updated by the Joomla updater.

IMO, removing free plugins from the fabrikar.com download page will simplify it and give greater focus to subscribing to get the subscription-only plugins.