### PR TITLE
[minor] List Grouped: No spaces around number of rows

### DIFF
--- a/components/com_fabrik/layouts/list/fabrik-group-by-heading.php
+++ b/components/com_fabrik/layouts/list/fabrik-group-by-heading.php
@@ -26,8 +26,7 @@ $imgProps = array('alt' => FText::_('COM_FABRIK_TOGGLE'), 'data-role' => 'toggle
 			<?php echo $d->title; ?> 
 			<?php $d->group_by_show_count = isset($d->group_by_show_count) ? $d->group_by_show_count : '1'; 
 			if ($d->group_by_show_count) : ?>
-				<span class="groupCount">( <?php echo $d->count ?> )</span>
+				<span class="groupCount">(<?php echo $d->count ?>)</span>
 			<?php endif; ?>			
 		</span>
 	</a>
-


### PR DESCRIPTION
Replace:
```
> Group ( 5 )
```
with
```
> Group (5)
```