### PR TITLE
[minor] Fix empty dropdown when php event list plugin used

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -7111,7 +7111,7 @@ class FabrikFEModelList extends JModelForm
 			}
 
 			$pluginManager->runPlugins('button', $this, 'list', array('heading' => true));
-			$res = $pluginManager->data;
+			$res = array_filter($pluginManager->data);
 
 			if (FabrikWorker::j3())
 			{


### PR DESCRIPTION
![empty-dropdown](https://user-images.githubusercontent.com/3001893/34329616-369a838e-e8ff-11e7-97b4-e7a75cf3d28d.png)
