### PR TITLE
[minor] Do not display Go Back button in form module

### DIFF
--- a/components/com_fabrik/views/form/view.base.php
+++ b/components/com_fabrik/views/form/view.base.php
@@ -1087,6 +1087,10 @@ class FabrikViewFormBase extends FabrikView
 
 			$form->gobackButton = $params->get('goback_button', 0) ? $btnLayout->render($layoutData) : '';
 		}
+		else
+		{
+			$form->gobackButton = '';
+		}
 
 		if ($model->isEditable() && $params->get('submit_button', 1))
 		{

--- a/components/com_fabrik/views/form/view.base.php
+++ b/components/com_fabrik/views/form/view.base.php
@@ -1074,16 +1074,19 @@ class FabrikViewFormBase extends FabrikView
 		$multiPageSession = $model->sessionModel && $model->sessionModel->last_page > 0;
 		$form->clearMultipageSessionButton = $multiPageSession ? $btnLayout->render($layoutData) : '';
 
-		$layoutData = (object) array(
-			'type' => 'button',
-			'class' => 'button',
-			'name' => 'Goback',
-			'label' => $goBackLabel,
-			'attributes' => $model->isAjax() ? '' : FabrikWorker::goBackAction(),
-			'formModel' => $model
-		);
+		if (!$this->isMambot)
+		{
+			$layoutData = (object) array(
+				'type' => 'button',
+				'class' => 'button',
+				'name' => 'Goback',
+				'label' => $goBackLabel,
+				'attributes' => $model->isAjax() ? '' : FabrikWorker::goBackAction(),
+				'formModel' => $model
+			);
 
-		$form->gobackButton = $params->get('goback_button', 0) ? $btnLayout->render($layoutData) : '';
+			$form->gobackButton = $params->get('goback_button', 0) ? $btnLayout->render($layoutData) : '';
+		}
 
 		if ($model->isEditable() && $params->get('submit_button', 1))
 		{


### PR DESCRIPTION
If you have a Go Back button defined on your form (for when it is displayed normally), and you display the form in a module, then you do not want to display the Go Back button...

![mambot-back-button](https://user-images.githubusercontent.com/3001893/34393492-c200e8f8-eb4a-11e7-88a5-bf5c1e398933.png)
