### PR TITLE
Show mouse-over swatch color name next to 'Colour' in modal header to…

### DIFF
--- a/plugins/fabrik_element/colourpicker/colourpicker.js
+++ b/plugins/fabrik_element/colourpicker/colourpicker.js
@@ -281,7 +281,8 @@ define(['jquery', 'fab/element'], function (jQuery, FbElement) {
 			this.outputs = this.options.outputs;
 			this.redField = null;
 			this.widget = new Element('div');
-			this.colourNameOutput = new Element('span', {'stlye': 'padding:3px'}).inject(this.widget);
+			this.colourNameOutput = new Element('span', {'stlye': 'padding:3px'});
+			jQuery('.modal-header').append(this.colourNameOutput);
 			this.createColourSwatch(element);
 			return this.widget;
 		},


### PR DESCRIPTION

![colourpicker](https://user-images.githubusercontent.com/2026714/34843664-169aedc6-f6dd-11e7-9d72-9c3be61648dc.png)
… eliminated jitter from dynamically inserting color name  in swatch div.