### PR TITLE
[medium] If joomlaDB then get joomla db...

### DIFF
--- a/components/com_fabrik/models/connection.php
+++ b/components/com_fabrik/models/connection.php
@@ -197,7 +197,7 @@ class FabrikFEModelConnection extends FabModel
 		{
 			if ($this->isJdb())
 			{
-				$db = FabrikWorker::getDbo();
+				$db = FabrikWorker::getDbo(true);
 			}
 			else
 			{


### PR DESCRIPTION
... rather than Fabrik default.

Most cases these are the same, but if fabrik default connection is not the joomla DB, we will get wrong database.

Small, change, potentially significant impact.