### PR TITLE
[minor] Enhanced fconsole function that...

### DIFF
--- a/media/com_fabrik/js/utils.js
+++ b/media/com_fabrik/js/utils.js
@@ -6,11 +6,48 @@
  */
 function fconsole() {
     if (typeof (window.console) !== 'undefined') {
-        var str = '', i;
+
+        var output = [], current = null, i;
         for (i = 0; i < arguments.length; i++) {
-            str += arguments[i] + ' ';
+            var arg = arguments[i];
+            if (current === null) {
+                current = arg;
+            } else if (typeof current === 'object') {
+                if (current instanceof Element || current instanceof HTMLDocument) {
+                    output.push(current.cloneNode(true));
+                } else if (current instanceof Array) {
+                    output.push(current.slice(0));
+                } else {
+                    output.push(Object.assign({},current));
+                }
+                current = arg;
+            } else if (typeof arg === 'object') {
+                output.push(current);
+                current = arg;
+            } else { // both are strings or can be implicitly converted to strings
+                current += ' ' + arg;
+            }
         }
-        console.log(str);
+        if (typeof current === 'object') {
+            if (current instanceof Element || current instanceof HTMLDocument) {
+                output.push(current.cloneNode(true));
+            } else if (current instanceof Array) {
+                output.push(current.slice(0));
+            } else {
+                output.push(Object.assign({},current));
+            }
+        } else {
+            output.push(current);
+        }
+        if (output.length === 1) {
+            console.log(output[0]);
+        } else {
+            console.groupCollapsed(output[0]);
+            for (i = 1; i < output.length; i++) {
+                console.log(output[i]);
+            }
+            console.groupEnd();
+        }
     }
 }
 


### PR DESCRIPTION
1. Displays the value of objects at the time of logging not at the time of display.

If you log a dom element for example, it logs a pointer to the dynamic object in the document and when you look at the log you get the current state and not the state at the time it was logged. This version clones objects before displaying them so that you see the object as it was at the time of logging.

2. The current function converts objects to strings - and you lose the information therein.

This version clones the objects and displays them in a collapsed form.

Test with: `fconsole("test", "me", "please", {a:'a'}, [1,2], document);`