### PR TITLE
Fix and enhance Admin Elements list

### DIFF
--- a/administrator/components/com_fabrik/models/elements.php
+++ b/administrator/components/com_fabrik/models/elements.php
@@ -135,10 +135,20 @@ class FabrikAdminModelElements extends FabModelList
 
 		if ($orderCol == 'ordering' || $orderCol == 'category_title')
 		{
-			$orderCol = 'ordering';
+			$orderCol == 'e.ordering';
 		}
 
-		if (trim($orderCol) !== '')
+		if ($orderCol == 'e.ordering')
+		{
+			$query->order($db->quoteName('g.name') . ' ' .$orderDirn);
+			$query->order($db->quoteName('e.ordering') . ' ' .$orderDirn);
+		}
+		elseif ($orderCol == 'g.name')
+		{
+			$query->order($db->quoteName('g.name') . ' ' . $orderDirn);
+			$query->order($db->quoteName('e.ordering') . ' ASC');
+		}
+		elseif (trim($orderCol) !== '')
 		{
 			$query->order($db->escape($orderCol . ' ' . $orderDirn));
 		}
@@ -168,11 +178,9 @@ class FabrikAdminModelElements extends FabModelList
 			WHERE (jj.list_id != 0 AND jj.element_id = 0)
 			AND ee.id = e.id AND ee.group_id <> 0 AND ee.id IN (" . implode(',', $elementIds) . ") LIMIT 1)  AS full_element_name";
 
-			$query->select('u.name AS editor, ' . $fullname . ', g.name AS group_name, l.db_table_name');
+			$query->select('u.name AS editor, ' . $fullname . ', g.name AS group_name, g.id AS group_id, l.db_table_name');
 			$query->select("(SELECT GROUP_CONCAT(ec.id SEPARATOR ',') FROM #__{package}_elements AS ec WHERE ec.parent_id = e.id) AS child_ids");
 		}
-
-		//$sql = (string)$query;
 
 		return $query;
 	}
@@ -309,11 +317,20 @@ class FabrikAdminModelElements extends FabModelList
 		$this->setState('filter.search', $search);
 
 		// Load the form state
+		$currentForm = $app->getUserState($this->context . '.filter.form', '');
 		$form = $app->getUserStateFromRequest($this->context . '.filter.form', 'filter_form', '');
 		$this->setState('filter.form', $form);
 
 		// Load the group state
-		$group = $app->getUserStateFromRequest($this->context . '.filter.group', 'filter_group', '');
+		if ($form === $currentForm)
+		{
+			$group = $app->getUserStateFromRequest($this->context . '.filter.group', 'filter_group', '');
+		}
+		else
+		{
+			$group = '';
+			$app->setUserState($this->context . '.filter.group', '');
+		}
 		$this->setState('filter.group', $group);
 
 		// Load the show in list state

--- a/administrator/components/com_fabrik/views/elements/tmpl/bootstrap.php
+++ b/administrator/components/com_fabrik/views/elements/tmpl/bootstrap.php
@@ -26,7 +26,7 @@ $user	= JFactory::getUser();
 $userId	= $user->get('id');
 $listOrder	= $this->state->get('list.ordering');
 $listDirn	= $this->state->get('list.direction');
-$saveOrder	= $listOrder == 'e.ordering';
+$saveOrder	= $listOrder == 'e.ordering' || $listOrder == 'g.name' ;
 if ($saveOrder)
 {
 	$saveOrderingUrl = 'index.php?option=com_fabrik&task=elements.saveOrderAjax&tmpl=component';
@@ -143,7 +143,7 @@ $states	= array(
 				. '<br/><br/><strong>' . $item->numJs . ' ' . FText::_('COM_FABRIK_JAVASCRIPT') . '</strong>';
 			?>
 
-			<tr class="row<?php echo $i % 2; ?>">
+			<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->group_id; ?>">
 				<td>
 					<?php echo $item->id; ?>
 				</td>


### PR DESCRIPTION
1. Fix issue where group filter is not cleared when you change forms.

2. Combine sorting of the order and group columns so that:
a. If you sort by group, the elements are ordered ascending within the
group (regardless of ASC/DESC for the group itself) and drag / drop
reordering is enabled;
b. If you sort by ordering, then sorting is by group and order but
ASC/DESC is respected.

3. Drag and drop is now limited to the group that the element is in
(standard joomla functionality enabled by adding the group id as a
special attribute to the row div).