### PR TITLE
Allow dynamic changes to popover

### DIFF
--- a/media/com_fabrik/js/tipsBootStrapMock.js
+++ b/media/com_fabrik/js/tipsBootStrapMock.js
@@ -17,6 +17,7 @@ define(['jquery', 'fab/fabrik'], function (jQuery, Fabrik) {
             'position'  : 'top',
             'trigger'   : 'hover',
             'content'   : 'title',
+            'maxwidth'  : 276,
             'distance'  : 50,
             'tipfx'     : 'Fx.Transitions.linear',
             'heading'   : '',
@@ -173,7 +174,7 @@ define(['jquery', 'fab/fabrik'], function (jQuery, Fabrik) {
             },
 
             show: function () {
-                var $tip, inside, pos, actualWidth, actualHeight, placement, tp;
+                var $tip, inside, pos, actualWidth, actualHeight, placement, tp, leftpos;
                 if (this.hasContent() && this.enabled) {
                     $tip = this.tip();
                     this.setContent();
@@ -194,10 +195,18 @@ define(['jquery', 'fab/fabrik'], function (jQuery, Fabrik) {
 
                     actualWidth = $tip[0].offsetWidth;
                     actualHeight = $tip[0].offsetHeight;
-
+                    var maxwidth = Math.min(actualWidth,this.options.maxwidth);
+                    var xpos = parseInt(window.fabrikTipXpos);
+                    var tippos = inside ? placement.split(' ')[1] : placement;
                     switch (inside ? placement.split(' ')[1] : placement) {
                         case 'bottom':
-                            tp = {top: pos.top + pos.height, left: pos.left + pos.width / 2 - actualWidth / 2};
+                            leftpos = pos.left + pos.width / 2 - maxwidth / 2 ;
+                            // If tip is outside viewport, position tip to left/right edge of window (w/margin of 10px) 
+                            if (leftpos < 0) {leftpos = 10;} 
+                            if (leftpos + maxwidth > parseInt(jQuery(window).width())) {
+                                leftpos = parseInt(jQuery(window).width()) - maxwidth -10 ;
+                            } 
+                            tp = {'top': pos.top + pos.height, 'left': leftpos, 'max-width': maxwidth+'px'};
                             break;
                         case 'bottom-left':
                             tp = {top: pos.top + pos.height, left: pos.left};
@@ -208,7 +217,12 @@ define(['jquery', 'fab/fabrik'], function (jQuery, Fabrik) {
                             placement = 'bottom';
                             break;
                         case 'top':
-                            tp = {top: pos.top - actualHeight, left: pos.left + pos.width / 2 - actualWidth / 2};
+                            leftpos = pos.left + pos.width / 2 - maxwidth / 2 ;
+                            if (leftpos < 0) {leftpos = 10;} 
+                            if (leftpos + maxwidth > parseInt(jQuery(window).width())) {
+                                leftpos = parseInt(jQuery(window).width()) - maxwidth - 10;
+                            } 
+                            tp = {'top': pos.top - actualHeight, 'left': leftpos, 'max-width': maxwidth+'px'};
                             break;
                         case 'top-left':
                             tp = {top: pos.top - actualHeight, left: pos.left};
@@ -230,6 +244,13 @@ define(['jquery', 'fab/fabrik'], function (jQuery, Fabrik) {
                         .css(tp)
                         .addClass(placement)
                         .addClass('in');
+                    if ( (tippos.includes("top") || tippos.includes("bottom")) 
+                        && xpos > 0 && xpos > leftpos+15 && xpos < leftpos+maxwidth-15 ) {
+                        $tip.find("div.arrow").css('left',xpos-leftpos);
+                    }                           
+                    if(tippos.includes("top") && $tip[0].offsetHeight !== actualHeight){                       
+                        $tip.css("top",pos.top - $tip[0].offsetHeight);
+                    }                     
                 }
             }
         });


### PR DESCRIPTION
![notadjusted](https://user-images.githubusercontent.com/2026714/35932133-e4a3e60a-0c04-11e8-9402-0f18d1dbe66e.png)
Example of tip that is only partially visible because it goes off the left of the screen.
![adjusted_noarrowfix](https://user-images.githubusercontent.com/2026714/35932115-d478babc-0c04-11e8-8bb7-4cd779a55631.png)
Same tip after new  code adjustment (which has since been changed to include a 10px left margin).
But note that the arrow now incorrectly points to the adjacent button.
![adjusted_bad_arrow](https://user-images.githubusercontent.com/2026714/35932149-ee8d5264-0c04-11e8-911b-ca0fb804cc26.png)
Fix to position arrow correctly - based on the mouseover x-position when popover was triggered.
![adjusted_arrowfixed](https://user-images.githubusercontent.com/2026714/35932160-f6717bf4-0c04-11e8-9e8b-e48320584e76.png)
I finally figured out how to include the mouse cursor in a screen shot. Note how arrow was placed where the mouse pointer triggered the popover. 

As you see, these changes fix problems where wide tips in leftmost or rightmost columns might get truncated and pushed off to the left or right of the viewport.  

I know that 'the problem' with popovers on the right side of the screen had been fixed so they would not get truncated (I just never found where in the code that is done) - but it wasn't being fixed in the same manner as my solution. It would narrow the popover to accommodate rather than move it to the left.  That would then cause the height to change and, if set to display on 'top',  overlap the parent object - causing a flicker of the popover.

This solution accommodates for changes in popover height for popovers displayed on 'top' should the width get adjusted dynamically.

I have also created multiple samples for taking advantage of these code changes in list_xx.js, form_xx.js or details_.js javascript files (intended for the Wiki). - E.g. how to dynamically add tooltips of varying widths, titles, positions, and content to any list or form action buttons - and how to dynamically change an existing tooltip's title, content, width, or position - all via javascript.

And yes, I realize that this code does not include changes to top-right, top-left, bottom-right, bottom-left.  It is intended for using with 'top' or 'bottom' opts only ( though all positions still works the same as they always did). .  And between the automatic positioning of popovers on the far-right or far-left of the screen - and the automatic positioning of the popover arrow - I see no use for the top-right, top-left, bottom-right, bottom-left options anyhow.