### PR TITLE
Remove fix for t3 label-tip

### DIFF
--- a/media/com_fabrik/css/fabrik.css
+++ b/media/com_fabrik/css/fabrik.css
@@ -37,12 +37,6 @@ a.fabrikTip {
 	display: inline-block;
 }
 
-/** bootstrap 3 (possibly just t3 framework templates) remove the label if it has a tip on it
-when you move the mouse out of the label */
-label.fabrikLabel.fabrikTip, span.fabrikTip {
-	display:inline!important
-}
-
 /** bootstrap 3 fix */
 .fabrikButtonsContainer  li.dropdown {
 	display:inline!important


### PR DESCRIPTION
This has been like this for at least a year - and requires a change every time I update from Github.

With this css code, when using the standard Joomla templates the element labels lose their bottom margin - so there is no spacing at all between the label and the element if configured with labels 'on top'. 

Why not remove this style rule and put this 'corner case' responsibility on users who use t3 templates instead of inconveniencing all the rest of us?

/** bootstrap 3 (possibly just t3 framework templates) remove the label if it has a tip on it
when you move the mouse out of the label */
label.fabrikLabel.fabrikTip, span.fabrikTip {
	display:inline!important
}