### PR TITLE
Enable no zoom control in googlemaps

### DIFF
--- a/plugins/fabrik_element/googlemap/forms/fields.xml
+++ b/plugins/fabrik_element/googlemap/forms/fields.xml
@@ -136,7 +136,7 @@
 				description="PLG_ELEMENT_GOOGLE_MAP_CONTROL_DESC"
 				label="PLG_ELEMENT_GOOGLE_MAP_CONTROL_LABEL"
 				>
-					<option value="">None</option>
+					<option value="none">None</option>
 					<option value="GLargeMapControl">PLG_ELEMENT_GOOGLE_MAP_LARGE_MAP_CONTROL</option>
 					<option value="GSmallMapControl">PLG_ELEMENT_GOOGLE_MAP_SMALL_MAP_CONTROL</option>
 					<option value="GSmallZoomControl">PLG_ELEMENT_GOOGLE_MAP_SMALL_ZOOM_CONTROL</option>

--- a/plugins/fabrik_element/googlemap/googlemap.js
+++ b/plugins/fabrik_element/googlemap/googlemap.js
@@ -212,6 +212,7 @@ define(['jquery', 'fab/element', 'lib/debounce/jquery.ba-throttle-debounce', 'fa
             if (!this.options.staticmap) {
 
                 var zoomControlStyle = this.options.control === 'GSmallMapControl' ? google.maps.ZoomControlStyle.SMALL : google.maps.ZoomControlStyle.LARGE;
+				var vzoomControl = this.options.control !== 'none';
 
                 var mapOpts = {
                     center               : new google.maps.LatLng(this.options.lat, this.options.lon),
@@ -222,7 +223,7 @@ define(['jquery', 'fab/element', 'lib/debounce/jquery.ba-throttle-debounce', 'fa
                     overviewMapControl   : this.options.overviewcontrol,
                     scrollwheel          : this.options.scrollwheel,
                     streetViewControl    : this.options.streetView,
-                    zoomControl          : true,
+                    zoomControl          : vzoomControl,
                     zoomControlOptions   : {
                         style: zoomControlStyle
                     },

--- a/plugins/fabrik_element/googlemap/googlemap.js
+++ b/plugins/fabrik_element/googlemap/googlemap.js
@@ -212,7 +212,7 @@ define(['jquery', 'fab/element', 'lib/debounce/jquery.ba-throttle-debounce', 'fa
             if (!this.options.staticmap) {
 
                 var zoomControlStyle = this.options.control === 'GSmallMapControl' ? google.maps.ZoomControlStyle.SMALL : google.maps.ZoomControlStyle.LARGE;
-				var vzoomControl = this.options.control !== 'none';
+		var vzoomControl = this.options.control !== 'none';
 
                 var mapOpts = {
                     center               : new google.maps.LatLng(this.options.lat, this.options.lon),


### PR DESCRIPTION
http://fabrikar.com/forums/index.php?threads/google-map-element-control-always-returning-to-small-zoom.48893/#post-255320