### PR TITLE
Add code to include (append)  'Axis measurement unit' to 'Axis Label.'

### DIFF
--- a/plugins/fabrik_visualization/chart/models/chart.php
+++ b/plugins/fabrik_visualization/chart/models/chart.php
@@ -587,6 +587,13 @@ class FabrikModelChart extends FabrikFEModelVisualization
 					$axisLabels = explode('|', $glabels[0]);
 				}
 		}
+		
+        	$x_axis_measurement_unit = $params->get('x_axis_measurement_unit');          
+        	if ($x_axis_measurement_unit[0]) {
+            		for ($n=0; $n<count($axisLabels); $n++) {
+                		$axisLabels[$n] .= $x_axis_measurement_unit[0]; 
+            		}
+        	}
 
 		$this->axisLabels = $axisLabels;
 


### PR DESCRIPTION
The 'Axis measurement unit' option which was supposed to append text to a Chart axis label was not working; because, apparently, code was never included to checked for and add it.