### PR TITLE
More specific debugging help for list query

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -2695,7 +2695,8 @@ class FabrikFEModelList extends JModelForm
 			}
 			else
 			{
-				$query->where('2 = -2');
+				/= Bauer  changed from 2 = -2 for more specific help with debugging */
+				$query->where('3 = -3');
 			}
 		}
 		else


### PR DESCRIPTION
I came across this '(WHERE) 2 = -2 ' while using fabrikdebug and found it this code, TWICE. 
Changing one to "$query->where('3 = -3');"  will provide a  more specific debugging tool.