### PR TITLE
Fix onDeleteRows for php 7

### DIFF
--- a/plugins/fabrik_element/databasejoin/databasejoin.php
+++ b/plugins/fabrik_element/databasejoin/databasejoin.php
@@ -4027,19 +4027,15 @@ class PlgFabrik_ElementDatabasejoin extends PlgFabrik_ElementList
 		{
 			foreach ($group as $row)
 			{
-				$keys = array_merge($keys, explode(GROUPSPLITTER, $row->$fulName));
+				// Don't do anytyhing if nothing is selected
+				if($row->{$fulName}=="") return;
+				$pkval = $row->__pk_val;
 			}
 		}
 
 		$db = $this->getDb();
-		array_walk($keys, function (&$key) {
-			$db = $this->getDb();
-			$key = $db->q($key);
-		});
-
 		$query = $db->getQuery(true);
-		$query->delete($db->qn($join->table_join))->where('id IN (' . implode(',', $keys) .')');
-
+		$query->delete($db->qn($join->table_join))->where('parent_id='.$pkval);
 		return $db->setQuery($query)->execute();
 	}
 }


### PR DESCRIPTION
This was failing under php v.7. I hope the fix (adding {} brackets around variable used as object name) doe not break code for php less that v.7. 
There is no need to run query if databasejoin element is empty (nothing selected) - was returning WHERE id IN("")
Just delete based on parent_id (__pk_val) instead of building array of selected values