### PR TITLE
Fix DBJ onDeleteRows to catch blank values

### DIFF
--- a/plugins/fabrik_element/databasejoin/databasejoin.php
+++ b/plugins/fabrik_element/databasejoin/databasejoin.php
@@ -4018,19 +4018,21 @@ class PlgFabrik_ElementDatabasejoin extends PlgFabrik_ElementList
 		{
 			return;
 		}
-
 		$join  = $this->getJoin();
 		$keys = array();
 		$fulName = $this->getFullName(true, false) . '_raw';
-
 		foreach ($groups as $group)
 		{
 			foreach ($group as $row)
 			{
-				$keys = array_merge($keys, explode(GROUPSPLITTER, $row->$fulName));
-			}
+				if (!empty($row->$fulName))
+				{
+					$keys = array_merge($keys, explode(GROUPSPLITTER, $row->$fulName));
+				} 			}
 		}
-
+        
+		if(count($keys)==0) return;
+		
 		$db = $this->getDb();
 		array_walk($keys, function (&$key) {
 			$db = $this->getDb();
@@ -4039,7 +4041,6 @@ class PlgFabrik_ElementDatabasejoin extends PlgFabrik_ElementList
 
 		$query = $db->getQuery(true);
 		$query->delete($db->qn($join->table_join))->where('id IN (' . implode(',', $keys) .')');
-
 		return $db->setQuery($query)->execute();
 	}
 }


### PR DESCRIPTION
Any blank multiselect dbjs would produce error and cause the query to fail. 
So now this function checks for empty values and excludes from $keys array - then does not process the delete query if $keys array is empty.