### PR TITLE
Lowercase for column names

### DIFF
--- a/plugins/fabrik_element/user/user.php
+++ b/plugins/fabrik_element/user/user.php
@@ -897,6 +897,12 @@ class PlgFabrik_ElementUser extends PlgFabrik_ElementDatabasejoin
 		}
 
 		$this->encryptFieldName($k);
+		
+		//Otherwise it doesn't work with non-english characters
+		if(strtoupper($condition) === 'REGEXP' && stripos($value, 'LOWER') !== false){
+			$k = 'LOWER('.$k.')';
+		}
+		
 		$str = $k . ' ' . $condition . ' ' . $value;
 
 		return $str;


### PR DESCRIPTION
Otherwise it doesn't work with non-english characters