### PR TITLE
Change to the $subject variable.

### DIFF
--- a/plugins/fabrik_form/email/email.php
+++ b/plugins/fabrik_form/email/email.php
@@ -260,7 +260,7 @@ class PlgFabrik_FormEmail extends PlgFabrik_Form
 			$returnPathName = null;
 		}
 		// End changes
-		$subject = $params->get('email_subject');
+		$subject = FText::_($params->get('email_subject'));
 
 		if ($subject == '')
 		{


### PR DESCRIPTION
Allows to use a language override string as a mail subject for multilingual sites.