### PR TITLE
New feature: Custom Eval Message

### DIFF
--- a/plugins/fabrik_form/sms/sms.php
+++ b/plugins/fabrik_form/sms/sms.php
@@ -76,6 +76,16 @@ class PlgFabrik_FormSMS extends PlgFabrik_Form
 			$to     = array_merge($to, $toEval);
 			$to     = implode(',', $to);
 		}
+		
+		$customMessageEval = $params->get('sms_custom_eval_message', '');
+		$customSMSmessage     = array();
+
+		if (!empty($customMessageEval))
+		{
+			$customMessageEval = $w->parseMessageForPlaceholder($customMessageEval, $this->data, false);
+			$customSMSmessage     = @eval($customMessageEval);
+			FabrikWorker::logEval($customMessageEval, 'Caught exception on eval Custom SMS Message : %s');
+		}
 
 		if (empty($to))
 		{
@@ -88,7 +98,12 @@ class PlgFabrik_FormSMS extends PlgFabrik_Form
 		$opts['sms-to'] = $w->parseMessageForPlaceHolder($to, $data);
 
 
-		$message = $this->getMessage();
+		if (!empty($customMessageEval)){
+		   $message = $customSMSmessage;
+		}
+		else {
+		    $message = $this->getMessage();
+		}
 		$gateway = $this->getInstance();
 
 		return $gateway->process($message, $opts);


### PR DESCRIPTION
With this addition of custom eval Message, dynamic SMS messages can be sent with eval value / label from database join / drop down elements or using data from different table. The existing SMS Message field do not allow eval so only placeholders and plain text can be sent that too from same list table.