### PR TITLE
Clear last error before calling eval

### DIFF
--- a/components/com_fabrik/models/element.php
+++ b/components/com_fabrik/models/element.php
@@ -3932,6 +3932,9 @@ class PlgFabrik_Element extends FabrikPlugin
 				return $this->phpOptions[$key];
 			}
 
+			/* Clear any current errors, if anything happened before it will get picked up by the loEval and likely has nothing to do with the eval */
+			error_clear_last();
+			
 			if (FabrikHelperHTML::isDebug())
 			{
 				$res = eval($pop);


### PR DESCRIPTION
Prior to calling eval in the getPhpOptions, clear any current error condition. If Joomla debug is on and any warning etc is logged up to this point, it gets picked up and reported by the logEval call. The reported error likely has nothing to do with the eval PHP code. Clearing the last error ensures that logEval only captures errors with the eval'ed PHP.