### PR TITLE
JUser: :_load: Unable to load user with ID: 1 after validation failure

### DIFF
--- a/plugins/fabrik_form/juser/juser.php
+++ b/plugins/fabrik_form/juser/juser.php
@@ -184,7 +184,8 @@ class PlgFabrik_FormJUser extends plgFabrik_Form
 			if ($params->get('juser_sync_on_edit', 0) == 1)
 			{
 				$this->useridfield = $this->getFieldName('juser_field_userid');
-				$userId            = (int) FArrayHelper::getValue($formModel->data, $this->useridfield . '_raw');
+				// don't force it as an int, otherwise, is_array on line 193 won't work 
+				$userId            =  FArrayHelper::getValue($formModel->data, $this->useridfield . '_raw');
 				/**
 				 * $$$ hugh - after a validation failure, userid _raw is an array.
 				 * Trying to work out why, and fix that, but need a bandaid for now.


### PR DESCRIPTION
After a validation failure, userid _raw is an array.
Before this change, after validation failure, you'll receive a notice : JUser: :_load: Unable to load user with ID: 1
After this change, $userID is correct.