### PR TITLE
Update fabrik-element-calc-form.php

### DIFF
--- a/plugins/fabrik_element/calc/layouts/fabrik-element-calc-form.php
+++ b/plugins/fabrik_element/calc/layouts/fabrik-element-calc-form.php
@@ -1,6 +1,6 @@
 <?php
 defined('JPATH_BASE') or die;
-
+/* DEPRECATED
 $d = $displayData;
 if ($d->height <= 1) :
 ?>
@@ -11,3 +11,32 @@ else : ?>
 	id="<?php echo $d->id;?>" cols="<?php echo $d->cols; ?>"
 	rows="<?php echo $d->rows; ?>"><?php echo $d->value;?></textarea>
 <?php endif; ?>
+*/
+
+/* 06Feb2021 by Bruce Decker - rewrite to translate calc width to bootstrap class*/
+$d = $displayData;
+if($d->cols <= 15){
+	$bootWidth = 'input-small';
+} else {
+	if($d->cols <= 40){
+		$bootWidth = 'input-medium';
+	} else{
+		if ($d->cols <=60){
+			$bootWidth = 'input-large';
+		} else {
+			$bootWidth = 'input-xlarge';
+		}
+	} 
+}
+if ($d->height <= 1){
+	$htmlSnip = <<<HTMLSNIP
+	<span class="fabrikinput fabrikElementReadOnly" style="display:inline-block;" name="$d->name" id="$d->id" $d->value</span>
+	HTMLSNIP;
+} else {
+	$htmlSnip = <<<HTMLSNIP
+	<textarea class="fabrikinput $bootWidth" disabled="disabled" name="$d->name"
+	id="$d->id" cols="$d->cols" rows="$d->rows"$d->value></textarea>
+	HTMLSNIP;	
+}
+echo $htmlSnip;
+?>


### PR DESCRIPTION
Calc element had been written to use a class that had been defined as a static "input-medium" size and it would ignore the columns (width) param.  This update translates cols into bootstrap class definition to allow variable width based on cols.  Also cleaned up the code to use heredoc for the HTML.

Cons: Previous, cols were ignored in bootstrap templates.  Now, it will have an effect. A dev might need to adjust their cols param to suit and it's not obvious or documented  that the translation points are 15, 40, and 60.  If this commit is accepted, notify me and I'll update the wiki  - bruced@zumasys.com