### PR TITLE
PHP8: Add required 3rd param for Joomla

### DIFF
--- a/administrator/components/com_fabrik/controllers/groups.php
+++ b/administrator/components/com_fabrik/controllers/groups.php
@@ -45,7 +45,7 @@ class FabrikAdminControllerGroups extends FabControllerAdmin
 	 *
 	 * @return  J model
 	 */
-	public function &getModel($name = 'Group', $prefix = 'FabrikAdminModel')
+	public function &getModel($name = 'Group', $prefix = 'FabrikAdminModel', $config = [])
 	{
 		$model = parent::getModel($name, $prefix, array('ignore_request' => true));
 

--- a/administrator/components/com_fabrik/controllers/groups.php
+++ b/administrator/components/com_fabrik/controllers/groups.php
@@ -45,7 +45,7 @@ class FabrikAdminControllerGroups extends FabControllerAdmin
 	 *
 	 * @return  J model
 	 */
-	public function &getModel($name = 'Group', $prefix = 'FabrikAdminModel', $config = [])
+	public function &getModel($name = 'Group', $prefix = 'FabrikAdminModel', $config = array())
 	{
 		$model = parent::getModel($name, $prefix, array('ignore_request' => true));
 


### PR DESCRIPTION
With PHP8 when trying to unpublish a group, get the following error:

Fatal error: Declaration of & FabrikAdminControllerGroups::getModel($name = 'Group', $prefix = 'FabrikAdmi...') must be compatible with Joomla\CMS\MVC\Controller\BaseController::getModel($name = '', $prefix = '', $config = []) in /var/www/html/administrator/components/com_fabrik/controllers/groups.php on line 48

This PR adds the config parameter