### PR TITLE
Give the elGroupModel a default to make PHP8 happy

### DIFF
--- a/components/com_fabrik/models/list.php
+++ b/components/com_fabrik/models/list.php
@@ -9242,7 +9242,7 @@ class FabrikFEModelList extends JModelForm
 	 *
 	 * @return  bool
 	 */
-	public function fieldExists($field, $ignore = array(), $elGroupModel)
+	public function fieldExists($field, $ignore = array(), $elGroupModel = null)
 	{
 		$field = JString::strtolower($field);
 		$groupModels = $this->getFormGroupElementData();


### PR DESCRIPTION
As suggested by troester, gave the param a default rather than reorder. Closed the previous PR.