### PR TITLE
Replace form placeholders in dropdown_populate

### DIFF
--- a/components/com_fabrik/models/element.php
+++ b/components/com_fabrik/models/element.php
@@ -3963,7 +3963,7 @@ class PlgFabrik_Element extends FabrikPlugin
 		if ($pop !== '')
 		{
 			$w    = new FabrikWorker;
-			//$data = empty($data) ? $this->getFormModel()->getData() : $data;
+			$data = empty($data) ? $this->getFormModel()->getData() : $data;
 			$pop  = $w->parseMessageForPlaceHolder($pop, $data, false);
 
 			$key = md5($pop) . '-' . md5(serialize($data));


### PR DESCRIPTION
Line 3966 was commented out. This lead to form placeholders not being replaced in dropdown_populate fields.

Was there a reason that line was commented out?